### PR TITLE
Slider LoRA feature parity + NVFP4 & SageAttention support

### DIFF
--- a/docs/ltx_2.md
+++ b/docs/ltx_2.md
@@ -3030,6 +3030,7 @@ Learns a slider direction from positive/negative prompt pairs. No images or data
 ```toml
 mode = "text"
 guidance_strength = 1.0
+anchor_strength = 1.0
 sample_slider_range = [-2.0, -1.0, 0.0, 1.0, 2.0]
 
 [[targets]]
@@ -3037,6 +3038,12 @@ positive = "extremely detailed, sharp, high resolution, 8k"
 negative = "blurry, out of focus, low quality, soft"
 target_class = ""      # empty = affect all content
 weight = 1.0
+
+[[anchors]]
+prompt = "a portrait of a person"
+
+[[anchors]]
+prompt = "a landscape"
 ```
 
 - `guidance_strength`: Scales the directional offset applied to targets. Higher values = stronger direction signal but may overshoot.
@@ -3045,6 +3052,22 @@ weight = 1.0
 - `sample_slider_range`: Multiplier values used for preview samples during training.
 
 Multiple `[[targets]]` blocks can be defined to train several directions at once (e.g., detail + lighting).
+
+##### Anchors (concept preservation)
+
+Optional `[[anchors]]` blocks define concepts that should remain unchanged by the slider. For each anchor prompt, the frozen base model's prediction is computed once per step, and the LoRA is constrained to reproduce that same prediction at *both* slider multipliers (`+1` and `-1`). This prevents the slider from drifting on unrelated content — the classic concept-slider preservation technique.
+
+The per-step anchor loss (a plain MSE between the LoRA and frozen-base predictions) is intrinsically spiky in flow-matching velocity space: on ~90% of steps the LoRA barely moves the anchor prediction (loss ~1e-4), but on a small fraction of steps it deviates a lot. An offline probe over real predictions confirmed this spikiness is **not** a removable per-step scale factor — every per-step normalizer tried (variance-normalize, cosine, relative-MSE) still left a 1000-7000x dynamic range, because the variation lives in the genuine deviation, not in a divisible scale. Instead, each step's anchor loss is **capped at a multiple of its running median** (`anchor_cap_mult`), which bounds the rare gradient-norm spikes while leaving the typical steps untouched. This mirrors the spirit of Min-SNR-γ clamping. The cap is applied gradient-preservingly (the loss is scaled by a detached ratio), so the optimizer still moves in the anchor's direction — just not with explosive magnitude.
+
+> **Important — `loss/anchor` magnitude is NOT a measure of anchor impact.** The anchor loss value is typically tiny (~1% of `loss/average`) because it is a *squared* near-zero residual. Its *gradient*, however, is a non-squared, consistently-directed pull on the LoRA weights every step, so even a tiny loss value meaningfully constrains training. In practice, adding an anchor noticeably raises the steady-state direction loss (e.g. ~0.0048 → ~0.0078 on the skin-tone test) because the LoRA spends capacity preserving the anchor instead of maximizing the slide. That higher direction loss is the *cost of preservation*, working as designed — it does **not** mean training is broken. Judge anchor effectiveness from samples (does the anchor concept hold at ±2 while the slider direction still works), never from the `loss/anchor` number.
+
+- `[[anchors]]` / `prompt`: A text prompt describing a concept to preserve. Add as many blocks as needed.
+- `anchor_strength`: Weight on the anchor preservation loss (default `1.0`). Raise it if you observe drift on the anchor concept; lower it if the slider direction is being suppressed. Because the anchor's gradient pull is not proportional to its small loss value, treat this as an empirical knob tuned from samples.
+- `anchor_cap_mult`: Per-step spike cap, as a multiple of the running median anchor loss (default `5.0`, set `0` to disable). Lower values (3-5) clamp spikes harder and keep grad_norm calmer; higher values let more of the raw signal through. The cap only affects rare spike steps, so it stabilizes grad_norm **without** weakening the anchor's steady-state preservation pull (which comes from the ~90% of normal steps). The `loss/anchor` TensorBoard series reflects the post-cap value.
+
+Each anchor adds one extra row to both the no-grad reference forward pass and each gradient pass, so keep the anchor count small (typically 1-3). **Anchors apply to `text` mode only** — `reference` and `ic_reference` modes ignore them, since paired positive/negative examples already largely self-regularize the LoRA against unrelated drift.
+
+> **Choosing anchors:** A good anchor is a concept *adjacent to but not on* the slider's axis. For a slider that changes an attribute of people (e.g. skin tone), avoid anchors where the model will inject a person — "a city street" or "a t-shirt" will spawn a person whose attribute then sits on the slider axis and fights training. People-free nature/landscape prompts (e.g. `"a mountain valley at sunset, forest and rocks, no people"`) are the safest anchors for person-attribute sliders.
 
 #### Example Command (Text-Only)
 <sub>[↑ contents](#table-of-contents)</sub>

--- a/docs/ltx_2.md
+++ b/docs/ltx_2.md
@@ -3031,6 +3031,7 @@ Learns a slider direction from positive/negative prompt pairs. No images or data
 mode = "text"
 guidance_strength = 1.0
 anchor_strength = 1.0
+batch_all_targets = false   # true = train on every target each step (averaged)
 sample_slider_range = [-2.0, -1.0, 0.0, 1.0, 2.0]
 
 [[targets]]
@@ -3052,6 +3053,8 @@ prompt = "a landscape"
 - `sample_slider_range`: Multiplier values used for preview samples during training.
 
 Multiple `[[targets]]` blocks can be defined to train several directions at once (e.g., detail + lighting).
+
+- `batch_all_targets`: Text mode only (default `false`). When `false`, one target is picked at random each step. When `true`, **every** target is processed in the same step and their gradients are averaged (each target's loss scaled by `1/N`) into a single optimizer update. Averaging yields a lower-variance, more context-general direction — the signal shared across targets reinforces while context-specific noise partially cancels — at roughly `N x` the per-step compute. This is **not** equivalent to simply training longer: doubling steps applies sequential, separately-clipped updates that can interfere, whereas batching reconciles all targets in one move. If anchors are configured, the anchor loss is scaled by the same `1/N`, so anchor magnitude/behaviour is unchanged versus the non-batched path.
 
 ##### Anchors (concept preservation)
 

--- a/src/musubi_tuner/gui_dashboard/command_builder.py
+++ b/src/musubi_tuner/gui_dashboard/command_builder.py
@@ -2375,8 +2375,10 @@ def build_slider_training_cmd(config: ProjectConfig) -> list[str]:
     # Timestep / sigma distribution — slider reads these via getattr in its loop.
     # Excludes timestep_sampling/discrete_flow_shift/weighting_scheme (slider hardcodes
     # shifted_logit_normal sampling) and guidance_scale (slider uses its own guidance_strength).
-    if t.logit_mean is not None:
-        cmd += ["--logit_mean", str(t.logit_mean)]
+    # --logit_mean is intentionally NOT forwarded: it belongs to the standard
+    # logit_normal weighting scheme. The slider's shifted_logit_normal sampler takes
+    # its mean from the per-sequence-length shift (or --shifted_logit_shift), so
+    # logit_mean would be inert for sliders. --shifted_logit_shift is the equivalent.
     if t.logit_std is not None:
         cmd += ["--logit_std", str(t.logit_std)]
     if t.min_timestep is not None:
@@ -2472,6 +2474,10 @@ def build_slider_training_cmd(config: ProjectConfig) -> list[str]:
         cmd += ["--metadata_license", t.metadata_license]
     if t.metadata_tags:
         cmd += ["--metadata_tags", t.metadata_tags]
+    if t.metadata_reso:
+        cmd += ["--metadata_reso", t.metadata_reso]
+    if t.metadata_arch:
+        cmd += ["--metadata_arch", t.metadata_arch]
 
     # Sampling — inherited from training config (same pattern as build_training_cmd)
     sample_prompts = _effective_training_sample_prompts(config)

--- a/src/musubi_tuner/gui_dashboard/command_builder.py
+++ b/src/musubi_tuner/gui_dashboard/command_builder.py
@@ -1654,8 +1654,12 @@ def build_full_finetune_cmd(config: ProjectConfig) -> list[str]:
         cmd.append("--fp8_base")
     if t.fp8_scaled:
         cmd.append("--fp8_scaled")
-    if t.fp8_keep_blocks:
+    if getattr(t, "fp8_keep_blocks", ""):
         cmd += ["--fp8_keep_blocks", t.fp8_keep_blocks]
+    if t.nf4_base:
+        cmd.append("--nf4_base")
+    if getattr(t, "nf4_block_size", 32) != 32:
+        cmd += ["--nf4_block_size", str(t.nf4_block_size)]
     if t.flash_attn:
         cmd.append("--flash_attn")
     if t.flash3:

--- a/src/musubi_tuner/gui_dashboard/command_builder.py
+++ b/src/musubi_tuner/gui_dashboard/command_builder.py
@@ -50,7 +50,12 @@ def _effective_gemma_root(config: ProjectConfig, explicit: str, gemma_safetensor
     return explicit or config.default_gemma_root or str(_default_model_dir(config) / DEFAULT_GEMMA_ROOT_NAME)
 
 
-def _effective_gemma_safetensors(config: ProjectConfig, explicit: str) -> str:
+def _effective_gemma_safetensors(config: ProjectConfig, explicit: str, explicit_gemma_root: str = "") -> str:
+    # If the user has explicitly set gemma_root on this section AND it points to
+    # a real directory, suppress the default_gemma_safetensors fallback so that
+    # gemma_root takes priority.
+    if explicit_gemma_root and Path(explicit_gemma_root).is_dir():
+        return explicit or ""
     return explicit or config.default_gemma_safetensors or ""
 
 
@@ -359,7 +364,7 @@ def build_cache_text_cmd(config: ProjectConfig) -> list[str]:
     c = config.caching
     t = config.training
     ltx2_checkpoint = _effective_ltx2_checkpoint(config, c.ltx2_checkpoint)
-    gemma_safetensors = _effective_gemma_safetensors(config, c.gemma_safetensors)
+    gemma_safetensors = _effective_gemma_safetensors(config, c.gemma_safetensors, c.gemma_root)
     gemma_root = _effective_gemma_root(config, c.gemma_root, gemma_safetensors)
     sample_prompts = _effective_caching_sample_prompts(config)
 
@@ -443,7 +448,7 @@ def build_cache_text_cmd(config: ProjectConfig) -> list[str]:
 def build_inference_cmd(config: ProjectConfig) -> list[str]:
     """Build CLI args for ltx2_generate_video.py."""
     s = config.inference
-    gemma_safetensors = _effective_gemma_safetensors(config, s.gemma_safetensors)
+    gemma_safetensors = _effective_gemma_safetensors(config, s.gemma_safetensors, s.gemma_root)
     gemma_root = _effective_gemma_root(config, s.gemma_root, gemma_safetensors)
 
     cmd = [
@@ -681,7 +686,7 @@ def build_training_cmd(config: ProjectConfig) -> list[str]:
     toml_path = export_dataset_toml(config)
     t = config.training
     ltx2_checkpoint = _effective_ltx2_checkpoint(config, t.ltx2_checkpoint)
-    gemma_safetensors = _effective_gemma_safetensors(config, t.gemma_safetensors)
+    gemma_safetensors = _effective_gemma_safetensors(config, t.gemma_safetensors, t.gemma_root)
     gemma_root = _effective_gemma_root(config, t.gemma_root, gemma_safetensors)
     network_module = _effective_training_network_module(t)
     sample_prompts = _effective_training_sample_prompts(config)
@@ -1620,7 +1625,7 @@ def build_full_finetune_cmd(config: ProjectConfig) -> list[str]:
     toml_path = export_dataset_toml(config)
     t = config.full_finetune
     ltx2_checkpoint = _effective_ltx2_checkpoint(config, t.ltx2_checkpoint)
-    gemma_safetensors = _effective_gemma_safetensors(config, t.gemma_safetensors)
+    gemma_safetensors = _effective_gemma_safetensors(config, t.gemma_safetensors, t.gemma_root)
     gemma_root = _effective_gemma_root(config, t.gemma_root, gemma_safetensors)
     sample_prompts = _effective_full_finetune_sample_prompts(config)
 
@@ -2233,7 +2238,7 @@ def build_slider_training_cmd(config: ProjectConfig) -> list[str]:
     t = config.training
     slider_toml = _write_slider_toml(config, build_slider_toml_path(config))
     ltx2_checkpoint = _effective_ltx2_checkpoint(config, t.ltx2_checkpoint)
-    gemma_safetensors = _effective_gemma_safetensors(config, t.gemma_safetensors)
+    gemma_safetensors = _effective_gemma_safetensors(config, t.gemma_safetensors, t.gemma_root)
     gemma_root = _effective_gemma_root(config, t.gemma_root, gemma_safetensors)
     network_module = _effective_training_network_module(t)
     network_args_parts = _training_network_args_parts(t)

--- a/src/musubi_tuner/gui_dashboard/command_builder.py
+++ b/src/musubi_tuner/gui_dashboard/command_builder.py
@@ -2329,6 +2329,34 @@ def build_slider_training_cmd(config: ProjectConfig) -> list[str]:
         cmd += ["--output_name", s.output_name]
     if t.save_every_n_steps:
         cmd += ["--save_every_n_steps", str(t.save_every_n_steps)]
+    if t.autoresume:
+        cmd.append("--autoresume")
+
+    # Sampling — inherited from training config (same pattern as build_training_cmd)
+    sample_prompts = _effective_training_sample_prompts(config)
+    if t.sample_every_n_steps:
+        cmd += ["--sample_every_n_steps", str(t.sample_every_n_steps)]
+    if t.sample_every_n_epochs:
+        cmd += ["--sample_every_n_epochs", str(t.sample_every_n_epochs)]
+    if sample_prompts:
+        cmd += ["--sample_prompts", sample_prompts]
+    if t.sample_at_first:
+        cmd.append("--sample_at_first")
+    cmd += ["--sample_sampling_preset", t.sample_sampling_preset]
+    if t.sample_sigma_schedule != "auto":
+        cmd += ["--sample_sigma_schedule", t.sample_sigma_schedule]
+    if t.sample_sampler != "auto":
+        cmd += ["--sample_sampler", t.sample_sampler]
+    if t.sample_use_default_negative_prompt is True:
+        cmd.append("--sample_use_default_negative_prompt")
+    elif t.sample_use_default_negative_prompt is False:
+        cmd.append("--no-sample_use_default_negative_prompt")
+    if t.sample_with_offloading:
+        cmd.append("--sample_with_offloading")
+    _append_optional(cmd, "--height", t.height)
+    _append_optional(cmd, "--width", t.width)
+    _append_optional(cmd, "--sample_num_frames", t.sample_num_frames)
+    _append_optional(cmd, "--video_cfg_scale", t.video_cfg_scale)
 
     cmd += _split_cli_args(s.extra_args)
     return cmd

--- a/src/musubi_tuner/gui_dashboard/command_builder.py
+++ b/src/musubi_tuner/gui_dashboard/command_builder.py
@@ -2294,6 +2294,10 @@ def build_slider_training_cmd(config: ProjectConfig) -> list[str]:
         cmd += ["--latent_frames", str(s.latent_frames)]
         cmd += ["--latent_height", str(s.latent_height)]
         cmd += ["--latent_width", str(s.latent_width)]
+    else:
+        # First-frame conditioning probability — only meaningful for reference
+        # (image/video pair) sliders, read by the reference training step.
+        cmd += ["--ltx2_first_frame_conditioning_p", str(t.ltx2_first_frame_conditioning_p)]
     if s.guidance_strength != 1.0:
         cmd += ["--guidance_strength", str(s.guidance_strength)]
     if s.sample_slider_range != "-2,-1,0,1,2":
@@ -2307,6 +2311,30 @@ def build_slider_training_cmd(config: ProjectConfig) -> list[str]:
         cmd += ["--network_alpha", str(t.network_alpha)]
     if network_args_parts:
         cmd += ["--network_args"] + network_args_parts
+
+    # Network module + args — from training config.
+    # The slider trainer only defaults network_module when it is None, so forwarding
+    # the GUI value (and ic_reference override above) is safe.
+    network_args_parts = _split_cli_args(t.network_args)
+    _append_network_arg(network_args_parts, "rank_dropout", t.rank_dropout)
+    _append_network_arg(network_args_parts, "module_dropout", t.module_dropout)
+    _append_network_arg(network_args_parts, "use_dora", t.use_dora)
+    _append_network_arg(network_args_parts, "adaptive_rank", t.adaptive_rank)
+    _append_network_arg(network_args_parts, "adaptive_rank_target", t.adaptive_rank_target)
+    _append_network_arg(network_args_parts, "adaptive_rank_min_rank", t.adaptive_rank_min_rank)
+    _append_network_arg(network_args_parts, "adaptive_rank_init_rank", t.adaptive_rank_init_rank)
+    _append_network_arg(network_args_parts, "adaptive_rank_quantile", t.adaptive_rank_quantile)
+    _append_network_arg(network_args_parts, "adaptive_rank_weight", t.adaptive_rank_weight)
+    if t.network_module:
+        cmd += ["--network_module", _effective_network_module(t.network_module)]
+    if network_args_parts:
+        cmd += ["--network_args"] + network_args_parts
+    if t.network_weights:
+        cmd += ["--network_weights", t.network_weights]
+    if t.network_dropout is not None:
+        cmd += ["--network_dropout", str(t.network_dropout)]
+    if t.scale_weight_norms is not None:
+        cmd += ["--scale_weight_norms", str(t.scale_weight_norms)]
 
     # Optimizer — from training config
     cmd += ["--learning_rate", str(t.learning_rate)]

--- a/src/musubi_tuner/gui_dashboard/command_builder.py
+++ b/src/musubi_tuner/gui_dashboard/command_builder.py
@@ -2379,6 +2379,12 @@ def build_slider_training_cmd(config: ProjectConfig) -> list[str]:
         cmd += ["--log_cuda_memory_every_n_steps", str(t.log_cuda_memory_every_n_steps)]
     if t.save_checkpoint_metadata:
         cmd.append("--save_checkpoint_metadata")
+    if t.no_metadata:
+        cmd.append("--no_metadata")
+    if t.no_convert_to_comfy:
+        cmd.append("--no_convert_to_comfy")
+    if not t.save_original_lora:
+        cmd.append("--no_save_original_lora")
 
     cmd += _split_cli_args(s.extra_args)
     return cmd

--- a/src/musubi_tuner/gui_dashboard/command_builder.py
+++ b/src/musubi_tuner/gui_dashboard/command_builder.py
@@ -2358,6 +2358,28 @@ def build_slider_training_cmd(config: ProjectConfig) -> list[str]:
     _append_optional(cmd, "--sample_num_frames", t.sample_num_frames)
     _append_optional(cmd, "--video_cfg_scale", t.video_cfg_scale)
 
+    # Logging — inherited from training config (same pattern as build_training_cmd)
+    if t.log_with:
+        cmd += ["--log_with", t.log_with]
+    if t.log_with and t.logging_dir:
+        cmd += ["--logging_dir", t.logging_dir]
+    if t.log_prefix:
+        cmd += ["--log_prefix", t.log_prefix]
+    if t.log_tracker_name:
+        cmd += ["--log_tracker_name", t.log_tracker_name]
+    if t.log_tracker_config:
+        cmd += ["--log_tracker_config", t.log_tracker_config]
+    if t.log_config:
+        cmd.append("--log_config")
+    if t.wandb_run_name:
+        cmd += ["--wandb_run_name", t.wandb_run_name]
+    if t.wandb_api_key:
+        cmd += ["--wandb_api_key", t.wandb_api_key]
+    if t.log_cuda_memory_every_n_steps is not None:
+        cmd += ["--log_cuda_memory_every_n_steps", str(t.log_cuda_memory_every_n_steps)]
+    if t.save_checkpoint_metadata:
+        cmd.append("--save_checkpoint_metadata")
+
     cmd += _split_cli_args(s.extra_args)
     return cmd
 

--- a/src/musubi_tuner/gui_dashboard/command_builder.py
+++ b/src/musubi_tuner/gui_dashboard/command_builder.py
@@ -2270,6 +2270,14 @@ def build_slider_training_cmd(config: ProjectConfig) -> list[str]:
         cmd += ["--fp8_keep_blocks", t.fp8_keep_blocks]
     if t.flash_attn:
         cmd.append("--flash_attn")
+    if t.flash3:
+        cmd.append("--flash3")
+    if t.sdpa:
+        cmd.append("--sdpa")
+    if t.sage_attn:
+        cmd.append("--sage_attn")
+    if t.xformers:
+        cmd.append("--xformers")
     if t.gemma_load_in_8bit:
         cmd.append("--gemma_load_in_8bit")
     if t.gemma_load_in_4bit:
@@ -2309,10 +2317,54 @@ def build_slider_training_cmd(config: ProjectConfig) -> list[str]:
     cmd += ["--gradient_accumulation_steps", str(t.gradient_accumulation_steps)]
     cmd += ["--max_grad_norm", str(t.max_grad_norm)]
 
+    # LR scheduler — from training config
+    cmd += ["--lr_scheduler", t.lr_scheduler]
+    cmd += ["--lr_warmup_steps", str(t.lr_warmup_steps)]
+    if t.lr_decay_steps is not None:
+        cmd += ["--lr_decay_steps", str(t.lr_decay_steps)]
+    if t.lr_scheduler_num_cycles is not None:
+        cmd += ["--lr_scheduler_num_cycles", str(t.lr_scheduler_num_cycles)]
+    if t.lr_scheduler_power is not None:
+        cmd += ["--lr_scheduler_power", str(t.lr_scheduler_power)]
+    if t.lr_scheduler_min_lr_ratio is not None:
+        cmd += ["--lr_scheduler_min_lr_ratio", str(t.lr_scheduler_min_lr_ratio)]
+    if t.lr_scheduler_type:
+        cmd += ["--lr_scheduler_type", t.lr_scheduler_type]
+    if t.lr_scheduler_args:
+        cmd += ["--lr_scheduler_args"] + _split_cli_args(t.lr_scheduler_args)
+    if t.lr_scheduler_timescale is not None:
+        cmd += ["--lr_scheduler_timescale", str(t.lr_scheduler_timescale)]
+
     # Schedule — slider override for steps
     cmd += ["--max_train_steps", str(s.max_train_steps)]
     if t.seed is not None:
         cmd += ["--seed", str(t.seed)]
+
+    # Timestep / sigma distribution — slider reads these via getattr in its loop.
+    # Excludes timestep_sampling/discrete_flow_shift/weighting_scheme (slider hardcodes
+    # shifted_logit_normal sampling) and guidance_scale (slider uses its own guidance_strength).
+    if t.logit_mean is not None:
+        cmd += ["--logit_mean", str(t.logit_mean)]
+    if t.logit_std is not None:
+        cmd += ["--logit_std", str(t.logit_std)]
+    if t.min_timestep is not None:
+        cmd += ["--min_timestep", str(t.min_timestep)]
+    if t.max_timestep is not None:
+        cmd += ["--max_timestep", str(t.max_timestep)]
+    if t.shifted_logit_mode:
+        cmd += ["--shifted_logit_mode", t.shifted_logit_mode]
+    if t.shifted_logit_eps != 1e-3:
+        cmd += ["--shifted_logit_eps", str(t.shifted_logit_eps)]
+    if t.shifted_logit_uniform_prob != 0.1:
+        cmd += ["--shifted_logit_uniform_prob", str(t.shifted_logit_uniform_prob)]
+    if t.shifted_logit_shift is not None:
+        cmd += ["--shifted_logit_shift", str(t.shifted_logit_shift)]
+    if t.shifted_logit_clamp_auto_shift:
+        cmd.append("--shifted_logit_clamp_auto_shift")
+    if t.shifted_logit_min_shift != 0.95:
+        cmd += ["--shifted_logit_min_shift", str(t.shifted_logit_min_shift)]
+    if t.shifted_logit_max_shift != 2.05:
+        cmd += ["--shifted_logit_max_shift", str(t.shifted_logit_max_shift)]
 
     # Memory — from training config
     if t.blocks_to_swap is not None:
@@ -2329,6 +2381,20 @@ def build_slider_training_cmd(config: ProjectConfig) -> list[str]:
         cmd += ["--output_name", s.output_name]
     if t.save_every_n_steps:
         cmd += ["--save_every_n_steps", str(t.save_every_n_steps)]
+    if t.save_last_n_steps is not None:
+        cmd += ["--save_last_n_steps", str(t.save_last_n_steps)]
+    if t.save_last_n_steps_state is not None:
+        cmd += ["--save_last_n_steps_state", str(t.save_last_n_steps_state)]
+    if t.save_state:
+        cmd.append("--save_state")
+    if t.save_state_on_train_end:
+        cmd.append("--save_state_on_train_end")
+    if t.resume:
+        cmd += ["--resume", t.resume]
+    if t.reset_optimizer:
+        cmd.append("--reset_optimizer")
+    if t.reset_optimizer_params:
+        cmd.append("--reset_optimizer_params")
     if t.autoresume:
         cmd.append("--autoresume")
 

--- a/src/musubi_tuner/gui_dashboard/command_builder.py
+++ b/src/musubi_tuner/gui_dashboard/command_builder.py
@@ -2257,6 +2257,10 @@ def build_slider_training_cmd(config: ProjectConfig) -> list[str]:
         cmd += ["--gemma_safetensors", gemma_safetensors]
     if t.ltx2_mode:
         cmd += ["--ltx2_mode", t.ltx2_mode]
+    if t.ltx_version:
+        cmd += ["--ltx_version", t.ltx_version]
+    if t.vae_dtype:
+        cmd += ["--vae_dtype", t.vae_dtype]
     if s.mode == "ic_reference":
         cmd += ["--lora_target_preset", "v2v"]
         cmd += ["--ic_lora_strategy", "v2v"]
@@ -2403,6 +2407,37 @@ def build_slider_training_cmd(config: ProjectConfig) -> list[str]:
         cmd.append("--use_pinned_memory_for_block_swap")
     _append_h2d_block_swap_args(cmd, t)
 
+    # Compile / dynamo — from training config
+    if t.compile:
+        cmd.append("--compile")
+        if t.compile_backend:
+            cmd += ["--compile_backend", t.compile_backend]
+        if t.compile_mode:
+            cmd += ["--compile_mode", t.compile_mode]
+        compile_dynamic = _compile_dynamic_value(t.compile_dynamic)
+        if compile_dynamic:
+            cmd += ["--compile_dynamic", compile_dynamic]
+        if t.compile_fullgraph:
+            cmd.append("--compile_fullgraph")
+        if t.compile_cache_size_limit is not None:
+            cmd += ["--compile_cache_size_limit", str(t.compile_cache_size_limit)]
+    if t.dynamo_backend != "NO":
+        cmd += ["--dynamo_backend", t.dynamo_backend]
+        if t.dynamo_mode:
+            cmd += ["--dynamo_mode", t.dynamo_mode]
+        if t.dynamo_fullgraph:
+            cmd.append("--dynamo_fullgraph")
+        if t.dynamo_dynamic:
+            cmd.append("--dynamo_dynamic")
+
+    # CUDA performance — from training config
+    if t.cuda_allow_tf32:
+        cmd.append("--cuda_allow_tf32")
+    if t.cuda_cudnn_benchmark:
+        cmd.append("--cuda_cudnn_benchmark")
+    if t.cuda_memory_fraction is not None:
+        cmd += ["--cuda_memory_fraction", str(t.cuda_memory_fraction)]
+
     # Output — dir from training, name from slider
     cmd += ["--output_dir", _effective_output_dir(t.output_dir)]
     if s.output_name:
@@ -2425,6 +2460,18 @@ def build_slider_training_cmd(config: ProjectConfig) -> list[str]:
         cmd.append("--reset_optimizer_params")
     if t.autoresume:
         cmd.append("--autoresume")
+
+    # Model metadata — embedded in saved safetensors, useful for distribution
+    if t.metadata_title:
+        cmd += ["--metadata_title", t.metadata_title]
+    if t.metadata_author:
+        cmd += ["--metadata_author", t.metadata_author]
+    if t.metadata_description:
+        cmd += ["--metadata_description", t.metadata_description]
+    if t.metadata_license:
+        cmd += ["--metadata_license", t.metadata_license]
+    if t.metadata_tags:
+        cmd += ["--metadata_tags", t.metadata_tags]
 
     # Sampling — inherited from training config (same pattern as build_training_cmd)
     sample_prompts = _effective_training_sample_prompts(config)

--- a/src/musubi_tuner/gui_dashboard/frontend/src/routes/caching/+page.svelte
+++ b/src/musubi_tuner/gui_dashboard/frontend/src/routes/caching/+page.svelte
@@ -64,8 +64,8 @@
 	let modelDir = $derived(defaultModelDir(cwd, $projectConfig));
 	let resolvedLtx = $derived(effectiveLtx2Checkpoint(cwd, $projectConfig, caching.ltx2_checkpoint || ''));
 	let activeGemmaSafetensors = $derived(effectiveGemmaSafetensors($projectConfig, caching.gemma_safetensors || ''));
-	let gemmaRootDisabled = $derived(Boolean(activeGemmaSafetensors));
-	let resolvedGemma = $derived(effectiveGemmaRoot(cwd, $projectConfig, caching.gemma_root || '', activeGemmaSafetensors));
+	let gemmaRootDisabled = $derived(Boolean(caching.gemma_safetensors));
+	let resolvedGemma = $derived(effectiveGemmaRoot(cwd, $projectConfig, caching.gemma_root || '', caching.gemma_safetensors || ''));
 	let scanTargetGemmaRoot = $derived(effectiveGemmaRoot(cwd, $projectConfig, caching.gemma_root || '', ''));
 	let downloadState = $derived($modelDownloadState.state || '');
 	let modelStatus = $derived($modelDownloadState.message || '');

--- a/src/musubi_tuner/gui_dashboard/frontend/src/routes/inference/+page.svelte
+++ b/src/musubi_tuner/gui_dashboard/frontend/src/routes/inference/+page.svelte
@@ -60,8 +60,8 @@
 	let modelDir = $derived(defaultModelDir(cwd, $projectConfig));
 	let resolvedLtx = $derived(effectiveLtx2Checkpoint(cwd, $projectConfig, s.ltx2_checkpoint || ''));
 	let activeGemmaSafetensors = $derived(effectiveGemmaSafetensors($projectConfig, s.gemma_safetensors || ''));
-	let gemmaRootDisabled = $derived(Boolean(activeGemmaSafetensors));
-	let resolvedGemma = $derived(effectiveGemmaRoot(cwd, $projectConfig, s.gemma_root || '', activeGemmaSafetensors));
+	let gemmaRootDisabled = $derived(Boolean(s.gemma_safetensors));
+	let resolvedGemma = $derived(effectiveGemmaRoot(cwd, $projectConfig, s.gemma_root || '', s.gemma_safetensors || ''));
 	let scanTargetGemmaRoot = $derived(effectiveGemmaRoot(cwd, $projectConfig, s.gemma_root || '', ''));
 	let downloadState = $derived($modelDownloadState.state || '');
 	let modelStatus = $derived($modelDownloadState.message || '');

--- a/src/musubi_tuner/gui_dashboard/frontend/src/routes/training/+page.svelte
+++ b/src/musubi_tuner/gui_dashboard/frontend/src/routes/training/+page.svelte
@@ -128,8 +128,8 @@
 	let modelDir = $derived(defaultModelDir(cwd, $projectConfig));
 	let resolvedLtx = $derived(effectiveLtx2Checkpoint(cwd, $projectConfig, t.ltx2_checkpoint || ''));
 	let activeGemmaSafetensors = $derived(effectiveGemmaSafetensors($projectConfig, t.gemma_safetensors || ''));
-	let gemmaRootDisabled = $derived(Boolean(activeGemmaSafetensors));
-	let resolvedGemma = $derived(effectiveGemmaRoot(cwd, $projectConfig, t.gemma_root || '', activeGemmaSafetensors));
+	let gemmaRootDisabled = $derived(Boolean(t.gemma_safetensors));
+	let resolvedGemma = $derived(effectiveGemmaRoot(cwd, $projectConfig, t.gemma_root || '', t.gemma_safetensors || ''));
 	let scanTargetGemmaRoot = $derived(effectiveGemmaRoot(cwd, $projectConfig, t.gemma_root || '', ''));
 	let downloadState = $derived($modelDownloadState.state || '');
 	let modelStatus = $derived($modelDownloadState.message || '');

--- a/src/musubi_tuner/gui_dashboard/frontend/src/routes/training/dashboard/+page.svelte
+++ b/src/musubi_tuner/gui_dashboard/frontend/src/routes/training/dashboard/+page.svelte
@@ -20,17 +20,27 @@
 
 	let rawTrainingStatus = $derived($processStatuses.training || { state: 'idle', exit_code: null });
 	let rawFullFinetuneStatus = $derived($processStatuses.full_finetune || { state: 'idle', exit_code: null });
+	let rawSliderStatus = $derived($processStatuses.slider_training || { state: 'idle', exit_code: null });
 	let activeProcessType = $derived.by(() => {
 		if (rawFullFinetuneStatus.state === 'running' || rawFullFinetuneStatus.state === 'stopping') return 'full_finetune';
+		if (rawSliderStatus.state === 'running' || rawSliderStatus.state === 'stopping') return 'slider_training';
 		if (rawTrainingStatus.state === 'running' || rawTrainingStatus.state === 'stopping') return 'training';
 		if (rawFullFinetuneStatus.state === 'finished' || rawFullFinetuneStatus.state === 'error') return 'full_finetune';
+		if (rawSliderStatus.state === 'finished' || rawSliderStatus.state === 'error') return 'slider_training';
 		return 'training';
 	});
+	// Slider training inherits output_dir and most settings from the training config section.
 	let t = $derived(activeProcessType === 'full_finetune' ? ($projectConfig?.full_finetune || {}) : ($projectConfig?.training || {}));
-	let trainingLive = $derived(activeProcessType === 'full_finetune'
-		? (rawFullFinetuneStatus.state === 'running' || rawFullFinetuneStatus.state === 'stopping')
-		: (rawTrainingStatus.state === 'running' || rawTrainingStatus.state === 'stopping'));
-	let trainingStatus = $derived(activeProcessType === 'full_finetune' ? rawFullFinetuneStatus : rawTrainingStatus);
+	let trainingLive = $derived.by(() => {
+		if (activeProcessType === 'full_finetune') return rawFullFinetuneStatus.state === 'running' || rawFullFinetuneStatus.state === 'stopping';
+		if (activeProcessType === 'slider_training') return rawSliderStatus.state === 'running' || rawSliderStatus.state === 'stopping';
+		return rawTrainingStatus.state === 'running' || rawTrainingStatus.state === 'stopping';
+	});
+	let trainingStatus = $derived.by(() => {
+		if (activeProcessType === 'full_finetune') return rawFullFinetuneStatus;
+		if (activeProcessType === 'slider_training') return rawSliderStatus;
+		return rawTrainingStatus;
+	});
 	let trainingLogs = $derived($processLogs[activeProcessType] || []);
 	let trainingActive = $derived(trainingLive);
 	let showDashboardData = $derived(trainingLive);
@@ -71,18 +81,22 @@
 
 	onMount(() => {
 		let disposed = false;
+		const allProcessTypes = ['training', 'full_finetune', 'slider_training'];
 		const init = async () => {
 			const statuses = await refreshStatuses();
 			if (disposed) return;
 			const trainingState = statuses?.training?.state;
 			const fullFinetuneState = statuses?.full_finetune?.state;
-			if (trainingState === 'running' || trainingState === 'stopping' || fullFinetuneState === 'running' || fullFinetuneState === 'stopping') {
-				await preloadLogsIfActive(['training', 'full_finetune']);
+			const sliderState = statuses?.slider_training?.state;
+			const anyActive = [trainingState, fullFinetuneState, sliderState].some(
+				s => s === 'running' || s === 'stopping'
+			);
+			if (anyActive) {
+				await preloadLogsIfActive(allProcessTypes);
 			} else {
 				clearMetrics();
 				clearStatus();
-				clearProcessLogs('training');
-				clearProcessLogs('full_finetune');
+				for (const pt of allProcessTypes) clearProcessLogs(pt);
 			}
 
 			await Promise.all([fetchSystemInfo(), fetchStats()]);
@@ -91,7 +105,7 @@
 
 		const systemInterval = setInterval(fetchSystemInfo, 1000);
 		const statsInterval = setInterval(fetchStats, 3000);
-		const logInterval = startLogPolling(['training', 'full_finetune'], 1000);
+		const logInterval = startLogPolling(allProcessTypes, 1000);
 		return () => {
 			disposed = true;
 			clearInterval(systemInterval);

--- a/src/musubi_tuner/gui_dashboard/frontend/src/routes/training/full-finetune/+page.svelte
+++ b/src/musubi_tuner/gui_dashboard/frontend/src/routes/training/full-finetune/+page.svelte
@@ -93,8 +93,8 @@
 	let modelDir = $derived(defaultModelDir(cwd, $projectConfig));
 	let resolvedLtx = $derived(effectiveLtx2Checkpoint(cwd, $projectConfig, t.ltx2_checkpoint || ''));
 	let activeGemmaSafetensors = $derived(effectiveGemmaSafetensors($projectConfig, t.gemma_safetensors || ''));
-	let gemmaRootDisabled = $derived(Boolean(activeGemmaSafetensors));
-	let resolvedGemma = $derived(effectiveGemmaRoot(cwd, $projectConfig, t.gemma_root || '', activeGemmaSafetensors));
+	let gemmaRootDisabled = $derived(Boolean(t.gemma_safetensors));
+	let resolvedGemma = $derived(effectiveGemmaRoot(cwd, $projectConfig, t.gemma_root || '', t.gemma_safetensors || ''));
 	let scanTargetGemmaRoot = $derived(effectiveGemmaRoot(cwd, $projectConfig, t.gemma_root || '', ''));
 	let downloadState = $derived($modelDownloadState.state || '');
 	let modelStatus = $derived($modelDownloadState.message || '');

--- a/src/musubi_tuner/gui_dashboard/frontend/src/routes/training/techniques/+page.svelte
+++ b/src/musubi_tuner/gui_dashboard/frontend/src/routes/training/techniques/+page.svelte
@@ -74,6 +74,7 @@
 
 	let targets = $derived($projectConfig?.slider?.targets || [{ positive: '', negative: '', target_class: '', weight: 1.0 }]);
 	let sliderStatus = $derived($processStatuses.slider_training || { state: 'idle', exit_code: null });
+	let sliderLogs = $derived($processLogs.slider_training || []);
 	let dinoStatus = $derived($processStatuses.cache_dino || { state: 'idle', exit_code: null });
 	let dinoLogs = $derived($processLogs.cache_dino || []);
 </script>
@@ -900,7 +901,7 @@
 				<div class="pt-2">
 					<ProcessControls processType="slider_training" status={sliderStatus} onStart={() => startProcess('slider_training')} onStop={() => stopProcess('slider_training')} />
 				</div>
-
+				<ProcessConsole lines={sliderLogs} processType="slider_training" />
 				<CommandPanel processType="slider_training" defaultFilename="slider_train.bat" />
 			</div>
 		</div>

--- a/src/musubi_tuner/gui_dashboard/frontend/src/routes/training/techniques/+page.svelte
+++ b/src/musubi_tuner/gui_dashboard/frontend/src/routes/training/techniques/+page.svelte
@@ -820,6 +820,7 @@
 										<FormField type="number" fieldPath="slider.latent_height" value={$projectConfig?.slider?.latent_height ?? 512} oninput={(e) => update('latent_height', Number(e.target.value))} min={64} step={64} tooltip="Synthetic latent height" />
 										<FormField type="number" fieldPath="slider.latent_width" value={$projectConfig?.slider?.latent_width ?? 768} oninput={(e) => update('latent_width', Number(e.target.value))} min={64} step={64} tooltip="Synthetic latent width" />
 									</div>
+									<FormToggle fieldPath="slider.batch_all_targets" checked={$projectConfig?.slider?.batch_all_targets ?? false} onchange={(e) => update('batch_all_targets', e.target.checked)} tooltip="Process ALL slider targets every step (gradients averaged into one update) instead of picking one target at random per step. Produces a more stable, context-general direction; ~Nx slower per step but visits every target each step." />
 								{:else}
 									<div class="grid grid-cols-2 gap-2">
 										<PathInput fieldPath="slider.pos_cache_dir" value={$projectConfig?.slider?.pos_cache_dir || ''} oninput={(e) => update('pos_cache_dir', e.target.value)} showFiles tooltip="Directory with positive latent caches" />

--- a/src/musubi_tuner/gui_dashboard/frontend/src/routes/training/techniques/+page.svelte
+++ b/src/musubi_tuner/gui_dashboard/frontend/src/routes/training/techniques/+page.svelte
@@ -56,6 +56,34 @@
 		saveProjectDebounced();
 	}
 
+	function updateAnchor(index, key, value) {
+		projectConfig.update((c) => {
+			if (!c) return c;
+			const anchors = [...(c.slider?.anchors || [])];
+			anchors[index] = { ...(anchors[index] || {}), [key]: value };
+			return { ...c, slider: { ...(c.slider || {}), anchors } };
+		});
+		saveProjectDebounced();
+	}
+
+	function addAnchor() {
+		projectConfig.update((c) => {
+			if (!c) return c;
+			const anchors = [...(c.slider?.anchors || []), { prompt: '' }];
+			return { ...c, slider: { ...(c.slider || {}), anchors } };
+		});
+		saveProjectDebounced();
+	}
+
+	function removeAnchor(index) {
+		projectConfig.update((c) => {
+			if (!c?.slider?.anchors) return c;
+			const anchors = c.slider.anchors.filter((_, i) => i !== index);
+			return { ...c, slider: { ...(c.slider || {}), anchors } };
+		});
+		saveProjectDebounced();
+	}
+
 	function updateTraining(key, value) {
 		projectConfig.update((c) => {
 			if (!c) return c;
@@ -73,6 +101,7 @@
 	}
 
 	let targets = $derived($projectConfig?.slider?.targets || [{ positive: '', negative: '', target_class: '', weight: 1.0 }]);
+	let anchors = $derived($projectConfig?.slider?.anchors || []);
 	let sliderStatus = $derived($processStatuses.slider_training || { state: 'idle', exit_code: null });
 	let sliderLogs = $derived($processLogs.slider_training || []);
 	let dinoStatus = $derived($processStatuses.cache_dino || { state: 'idle', exit_code: null });
@@ -779,7 +808,13 @@
 									<FormField fieldPath="slider.output_name" value={$projectConfig?.slider?.output_name || 'ltx2_slider'} oninput={(e) => update('output_name', e.target.value)} tooltip="Output filename prefix for slider LoRA" />
 								</div>
 								{#if ($projectConfig?.slider?.mode || 'text') === 'text'}
-									<FormField type="number" fieldPath="slider.guidance_strength" value={$projectConfig?.slider?.guidance_strength ?? 1.0} oninput={(e) => update('guidance_strength', Number(e.target.value))} step="0.1" min={0} tooltip="Guidance strength for text-mode training" />
+									<div class="grid grid-cols-2 gap-2">
+										<FormField type="number" fieldPath="slider.guidance_strength" value={$projectConfig?.slider?.guidance_strength ?? 1.0} oninput={(e) => update('guidance_strength', Number(e.target.value))} step="0.1" min={0} tooltip="Guidance strength for text-mode training" />
+										<FormField type="number" fieldPath="slider.anchor_strength" value={$projectConfig?.slider?.anchor_strength ?? 1.0} oninput={(e) => update('anchor_strength', Number(e.target.value))} step="0.1" min={0} tooltip="Weight on the anchor preservation loss (text mode only). Anchors keep listed concepts unchanged by the slider." />
+									</div>
+									<div class="grid grid-cols-2 gap-2">
+										<FormField type="number" fieldPath="slider.anchor_cap_mult" value={$projectConfig?.slider?.anchor_cap_mult ?? 5.0} oninput={(e) => update('anchor_cap_mult', Number(e.target.value))} step="1" min={0} tooltip="Caps per-step anchor loss at this multiple of its running median (0=off). Tames the rare spikes that inflate grad_norm. Lower (3-5) clamps harder." />
+									</div>
 									<div class="grid grid-cols-3 gap-2">
 										<FormField fieldPath="slider.latent_frames" label="Frames" type="number" value={$projectConfig?.slider?.latent_frames ?? 1} oninput={(e) => update('latent_frames', Number(e.target.value))} min={1} tooltip="Latent frames (1=image, >1=video)" />
 										<FormField type="number" fieldPath="slider.latent_height" value={$projectConfig?.slider?.latent_height ?? 512} oninput={(e) => update('latent_height', Number(e.target.value))} min={64} step={64} tooltip="Synthetic latent height" />
@@ -887,6 +922,57 @@
 										<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M12 6v12m6-6H6"/></svg>
 										Add Target
 									</button>
+
+									<!-- Anchors (concept preservation) -->
+									<div class="pt-3 mt-1" style="border-top: 1px solid var(--border-subtle);">
+										<div class="text-[11px] font-semibold mb-1" style="color: var(--text-primary);">Anchors</div>
+										<p class="text-[11px] leading-relaxed mb-2" style="color: var(--text-muted);">
+											Optional concepts to preserve. The slider is constrained to leave these prompts unchanged at both <code>+1</code> and <code>-1</code>, preventing drift on unrelated content. Keep the count small (1-3).
+										</p>
+										{#each anchors as anchor, i}
+											<div class="p-3 mb-2 space-y-2 relative" style="background: var(--bg-elevated); border-radius: var(--radius-sm); border: 1px solid var(--border-subtle);">
+												<div class="flex items-center justify-between">
+													<span class="text-[10px] font-semibold uppercase tracking-wider" style="color: var(--accent);">Anchor #{i + 1}</span>
+													<button
+														onclick={() => removeAnchor(i)}
+														class="px-2 py-0.5 text-[10px] font-medium"
+														style="color: var(--text-muted); background: var(--bg-elevated); border: 1px solid var(--border); border-radius: var(--radius-sm);"
+														onmouseenter={(e) => { e.currentTarget.style.color = 'var(--danger)'; e.currentTarget.style.borderColor = 'var(--danger)'; }}
+														onmouseleave={(e) => { e.currentTarget.style.color = 'var(--text-muted)'; e.currentTarget.style.borderColor = 'var(--border)'; }}
+													>
+														Remove
+													</button>
+												</div>
+												<!-- svelte-ignore a11y_label_has_associated_control -->
+												<label class="block">
+													<span class="flex items-center gap-1 text-[10px] font-medium mb-0.5" style="color: var(--text-secondary);">
+														<span>Preserve Prompt</span>
+														<FieldResetButton fieldPath={`slider.anchors.${i}.prompt`} />
+													</span>
+													<textarea
+														class="w-full text-[11px] px-2 py-1.5 resize-y"
+														rows="2"
+														value={anchor.prompt || ''}
+														oninput={(e) => updateAnchor(i, 'prompt', e.target.value)}
+														placeholder="a portrait of a person..."
+														style="background: var(--bg-surface); border: 1px solid var(--border); border-radius: var(--radius-sm); color: var(--text-primary); outline: none;"
+														onfocus={(e) => e.currentTarget.style.borderColor = 'var(--accent)'}
+														onblur={(e) => e.currentTarget.style.borderColor = 'var(--border)'}
+													></textarea>
+												</label>
+											</div>
+										{/each}
+										<button
+											onclick={addAnchor}
+											class="w-full py-1.5 text-[11px] font-medium flex items-center justify-center gap-1"
+											style="background: var(--bg-elevated); border: 1px dashed var(--border); color: var(--text-muted); border-radius: var(--radius-sm);"
+											onmouseenter={(e) => { e.currentTarget.style.borderColor = 'var(--accent)'; e.currentTarget.style.color = 'var(--accent)'; }}
+											onmouseleave={(e) => { e.currentTarget.style.borderColor = 'var(--border)'; e.currentTarget.style.color = 'var(--text-muted)'; }}
+										>
+											<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path d="M12 6v12m6-6H6"/></svg>
+											Add Anchor
+										</button>
+									</div>
 								{:else}
 									<p class="text-[11px] leading-relaxed" style="color: var(--text-muted);">
 										Reference-based slider modes use paired cached examples instead of prompt targets. The positive and negative samples must share basename-aligned cache files.

--- a/src/musubi_tuner/gui_dashboard/management_server.py
+++ b/src/musubi_tuner/gui_dashboard/management_server.py
@@ -207,7 +207,14 @@ def _get_run_dir(app: FastAPI) -> Optional[str]:
         return None
 
     pm: ProcessManager = app.state.process_manager
-    process_type = "full_finetune" if pm.get_status("full_finetune").get("state") in {"running", "stopping"} else "training"
+    active_states = {"running", "stopping"}
+    if pm.get_status("full_finetune").get("state") in active_states:
+        process_type = "full_finetune"
+    elif pm.get_status("slider_training").get("state") in active_states:
+        process_type = "slider_training"
+    else:
+        process_type = "training"
+    # Slider training inherits output_dir from the training config section.
     section = config.full_finetune if process_type == "full_finetune" else config.training
     if section.output_dir:
         run_dir = Path(section.output_dir)
@@ -220,5 +227,6 @@ def _get_run_dir(app: FastAPI) -> Optional[str]:
 def _training_dashboard_active(app: FastAPI) -> bool:
     pm: ProcessManager = app.state.process_manager
     return any(
-        pm.get_status(process_type).get("state") in {"running", "stopping"} for process_type in ("training", "full_finetune")
+        pm.get_status(process_type).get("state") in {"running", "stopping"}
+        for process_type in ("training", "full_finetune", "slider_training")
     )

--- a/src/musubi_tuner/gui_dashboard/metrics_writer.py
+++ b/src/musubi_tuner/gui_dashboard/metrics_writer.py
@@ -113,17 +113,32 @@ class MetricsWriter:
         entry = {"type": event_type, "step": step, "time": time.time(), **extra}
         self._append_event(entry)
 
-    def update_status(self, **kw):
+    def _compute_speed(self) -> tuple[float, float]:
+        """Return (elapsed_sec, speed_steps_per_sec) from the rolling step-time window."""
         if self._training_started_at is None:
-            elapsed = 0.0
-            speed = 0.0
+            return 0.0, 0.0
+        elapsed = time.monotonic() - self._training_started_at
+        if self._recent_step_times:
+            avg_step_time = sum(self._recent_step_times) / len(self._recent_step_times)
+            speed = 1.0 / avg_step_time if avg_step_time > 0 else 0.0
         else:
-            elapsed = time.monotonic() - self._training_started_at
-            if self._recent_step_times:
-                avg_step_time = sum(self._recent_step_times) / len(self._recent_step_times)
-                speed = 1.0 / avg_step_time if avg_step_time > 0 else 0.0
-            else:
-                speed = self._step_count / elapsed if elapsed > 0 and self._step_count > 0 else 0.0
+            speed = self._step_count / elapsed if elapsed > 0 and self._step_count > 0 else 0.0
+        return elapsed, speed
+
+    def current_sec_per_step(self) -> Optional[float]:
+        """Smoothed seconds-per-step (s/it), or None if no timing samples yet."""
+        _, speed = self._compute_speed()
+        return (1.0 / speed) if speed > 0 else None
+
+    def current_elapsed_sec(self) -> Optional[float]:
+        """Seconds since training timing began this session, or None if not started."""
+        if self._training_started_at is None:
+            return None
+        elapsed, _ = self._compute_speed()
+        return elapsed
+
+    def update_status(self, **kw):
+        elapsed, speed = self._compute_speed()
         status = {
             "elapsed_sec": round(elapsed, 1),
             "speed_steps_per_sec": round(speed, 4),

--- a/src/musubi_tuner/gui_dashboard/project_schema.py
+++ b/src/musubi_tuner/gui_dashboard/project_schema.py
@@ -955,6 +955,10 @@ class SliderTargetConfig(BaseModel):
     weight: float = 1.0
 
 
+class SliderAnchorConfig(BaseModel):
+    prompt: str = ""
+
+
 class SliderConfig(BaseModel):
     model_config = ConfigDict(extra="ignore")  # old projects may have fields that moved to TrainingConfig
 
@@ -969,8 +973,13 @@ class SliderConfig(BaseModel):
     # Targets (text-only mode)
     targets: list[SliderTargetConfig] = Field(default_factory=lambda: [SliderTargetConfig()])
 
+    # Anchors (text-only mode preservation)
+    anchors: list[SliderAnchorConfig] = Field(default_factory=list)
+
     # Text mode settings
     guidance_strength: float = 1.0
+    anchor_strength: float = 1.0
+    anchor_cap_mult: float = 5.0
     latent_frames: int = 1
     latent_height: int = 512
     latent_width: int = 768

--- a/src/musubi_tuner/gui_dashboard/project_schema.py
+++ b/src/musubi_tuner/gui_dashboard/project_schema.py
@@ -980,6 +980,7 @@ class SliderConfig(BaseModel):
     guidance_strength: float = 1.0
     anchor_strength: float = 1.0
     anchor_cap_mult: float = 5.0
+    batch_all_targets: bool = False
     latent_frames: int = 1
     latent_height: int = 512
     latent_width: int = 768

--- a/src/musubi_tuner/gui_dashboard/toml_export.py
+++ b/src/musubi_tuner/gui_dashboard/toml_export.py
@@ -294,6 +294,10 @@ def _write_slider_toml(config: ProjectConfig, output_path: Path) -> Path:
         "mode": s.mode,
         "guidance_strength": s.guidance_strength,
     }
+    # anchor settings only matter for text mode; emit when anchors are present
+    if s.mode == "text" and any((a.prompt or "").strip() for a in s.anchors):
+        doc["anchor_strength"] = s.anchor_strength
+        doc["anchor_cap_mult"] = s.anchor_cap_mult
     if s.reference_modality:
         doc["reference_modality"] = s.reference_modality
     if s.pos_cache_dir:
@@ -327,6 +331,13 @@ def _write_slider_toml(config: ProjectConfig, output_path: Path) -> Path:
             if target.target_class:
                 lines.append(f"target_class = {_toml_value(target.target_class)}")
             lines.append(f"weight = {target.weight}")
+            lines.append("")
+
+        for anchor in s.anchors:
+            if not (anchor.prompt or "").strip():
+                continue
+            lines.append("[[anchors]]")
+            lines.append(f"prompt = {_toml_value(anchor.prompt)}")
             lines.append("")
 
     output_path.write_text("\n".join(lines), encoding="utf-8")

--- a/src/musubi_tuner/gui_dashboard/toml_export.py
+++ b/src/musubi_tuner/gui_dashboard/toml_export.py
@@ -298,6 +298,9 @@ def _write_slider_toml(config: ProjectConfig, output_path: Path) -> Path:
     if s.mode == "text" and any((a.prompt or "").strip() for a in s.anchors):
         doc["anchor_strength"] = s.anchor_strength
         doc["anchor_cap_mult"] = s.anchor_cap_mult
+    # batch_all_targets is text-mode only; emit when enabled
+    if s.mode == "text" and s.batch_all_targets:
+        doc["batch_all_targets"] = s.batch_all_targets
     if s.reference_modality:
         doc["reference_modality"] = s.reference_modality
     if s.pos_cache_dir:

--- a/src/musubi_tuner/gui_dashboard/validation.py
+++ b/src/musubi_tuner/gui_dashboard/validation.py
@@ -270,9 +270,13 @@ def _has_cache_text_checkpoint(config: ProjectConfig) -> bool:
     return _has_text(config.caching.ltx2_checkpoint) or _has_text(config.default_ltx2_checkpoint)
 
 
-def _effective_gemma_safetensors(raw_path: str | None, default_path: str | None) -> str:
+def _effective_gemma_safetensors(raw_path: str | None, default_path: str | None, explicit_gemma_root: str | None = None) -> str:
     if _has_text(raw_path):
         return str(raw_path).strip()
+    # If the user explicitly set gemma_root to a valid directory, suppress the
+    # default_gemma_safetensors fallback so gemma_root takes priority.
+    if _has_text(explicit_gemma_root) and Path(str(explicit_gemma_root).strip()).is_dir():
+        return ""
     if _has_text(default_path):
         return str(default_path).strip()
     return ""
@@ -332,7 +336,7 @@ def validate_training_config(config: ProjectConfig) -> dict[str, Any]:
     t = config.training
     errors: list[dict[str, Any]] = []
     warnings: list[dict[str, Any]] = []
-    effective_gemma_safetensors = _effective_gemma_safetensors(t.gemma_safetensors, config.default_gemma_safetensors)
+    effective_gemma_safetensors = _effective_gemma_safetensors(t.gemma_safetensors, config.default_gemma_safetensors, t.gemma_root)
 
     if not _has_training_checkpoint(config):
         errors.append(
@@ -1275,7 +1279,7 @@ def validate_full_finetune_config(config: ProjectConfig) -> dict[str, Any]:
     t = config.full_finetune
     errors: list[dict[str, Any]] = []
     warnings: list[dict[str, Any]] = []
-    effective_gemma_safetensors = _effective_gemma_safetensors(t.gemma_safetensors, config.default_gemma_safetensors)
+    effective_gemma_safetensors = _effective_gemma_safetensors(t.gemma_safetensors, config.default_gemma_safetensors, t.gemma_root)
 
     if not _has_full_finetune_checkpoint(config):
         errors.append(
@@ -1785,7 +1789,7 @@ def validate_cache_text_config(config: ProjectConfig) -> dict[str, Any]:
     c = config.caching
     errors: list[dict[str, Any]] = []
     warnings: list[dict[str, Any]] = []
-    effective_gemma_safetensors = _effective_gemma_safetensors(c.gemma_safetensors, config.default_gemma_safetensors)
+    effective_gemma_safetensors = _effective_gemma_safetensors(c.gemma_safetensors, config.default_gemma_safetensors, c.gemma_root)
 
     if not _has_cache_text_checkpoint(config):
         errors.append(
@@ -1846,7 +1850,7 @@ def validate_inference_config(config: ProjectConfig) -> dict[str, Any]:
     i = config.inference
     errors: list[dict[str, Any]] = []
     warnings: list[dict[str, Any]] = []
-    effective_gemma_safetensors = _effective_gemma_safetensors(i.gemma_safetensors, config.default_gemma_safetensors)
+    effective_gemma_safetensors = _effective_gemma_safetensors(i.gemma_safetensors, config.default_gemma_safetensors, i.gemma_root)
 
     if not _has_inference_checkpoint(config):
         errors.append(

--- a/src/musubi_tuner/ltx2_model_loading.py
+++ b/src/musubi_tuner/ltx2_model_loading.py
@@ -677,6 +677,8 @@ def load_ltx2_model(
         attn_type = "flash_attention_3"
     elif attn_mode in {"flash", "flash_attention_2"}:
         attn_type = "flash_attention_2"
+    elif attn_mode in {"sageattn", "sage_attention"}:
+        attn_type = "sage_attention"
     elif attn_mode in {"torch", "sdpa"}:
         attn_type = "pytorch"
     if attn_type is not None:

--- a/src/musubi_tuner/ltx2_model_loading.py
+++ b/src/musubi_tuner/ltx2_model_loading.py
@@ -603,7 +603,9 @@ def load_ltx2_model(
 
     def _cast_non_fp8_params(model: torch.nn.Module, target_dtype: torch.dtype) -> None:
         for module in model.modules():
-            is_quantized_linear = isinstance(module, torch.nn.Linear) and hasattr(module, "scale_weight")
+            is_quantized_linear = isinstance(module, torch.nn.Linear) and (
+                hasattr(module, "scale_weight") or hasattr(module, "_nvfp4_quantized")
+            )
             if is_quantized_linear:
                 continue
             for _, param in module.named_parameters(recurse=False):
@@ -742,7 +744,23 @@ def load_ltx2_model(
 
     _awq_scales = None  # populated if AWQ calibration is used
 
-    if nf4_base:
+    # --- Auto-detect NVFP4 (Lightricks pre-quantized FP4 E2M1) ---
+    _is_nvfp4 = False
+    if not nf4_base and not fp8_scaled:
+        from musubi_tuner.modules.nvfp4_utils import detect_nvfp4_checkpoint
+        _check_path = model_path if isinstance(model_path, str) else model_path[0]
+        _is_nvfp4 = detect_nvfp4_checkpoint(_check_path)
+
+    if _is_nvfp4:
+        from musubi_tuner.modules.nvfp4_utils import load_nvfp4_state_dict, apply_nvfp4_monkey_patch
+        logger.info("Detected NVFP4 (Lightricks FP4 E2M1) checkpoint — loading with on-the-fly dequantization")
+        sd = load_nvfp4_state_dict(
+            model_files=model_path if isinstance(model_path, list) else [model_path],
+            state_dict_key_filter=state_dict_key_filter,
+            move_to_device=not load_weights_on_cpu and load_device == target_device,
+            target_device=load_device if (not load_weights_on_cpu and load_device == target_device) else None,
+        )
+    elif nf4_base:
         nf4_calc_device = _resolved_quant_device
         logger.info("LTX-2 nf4: quantization device = %s", nf4_calc_device)
         model_files = model_path if isinstance(model_path, list) else [model_path]
@@ -968,7 +986,10 @@ def load_ltx2_model(
             logger.info(f"[VRAM_TRACE_LTX2] {tag}: alloc={a:.2f}GB res={r:.2f}GB max={m:.2f}GB")
 
     _trace_vram_ltx2(f"AFTER state dict loading (state_device={state_device}, quantize_device={_resolved_quant_device})")
-    if nf4_base:
+    if _is_nvfp4:
+        from musubi_tuner.modules.nvfp4_utils import apply_nvfp4_monkey_patch
+        apply_nvfp4_monkey_patch(base_model, sd)
+    elif nf4_base:
         apply_nf4_monkey_patch(base_model, sd, block_size=nf4_block_size, awq_scales=_awq_scales)
     elif fp8_scaled:
         apply_fp8_monkey_patch(base_model, sd, use_scaled_mm=False)

--- a/src/musubi_tuner/ltx2_model_loading.py
+++ b/src/musubi_tuner/ltx2_model_loading.py
@@ -160,6 +160,13 @@ def detect_ltx2_dtype(model_path: str) -> torch.dtype:
     if not os.path.isfile(model_path):
         raise FileNotFoundError(f"LTX-2 weights must be a .safetensors file. Got: {model_path}")
 
+    # NVFP4 checkpoints store weight_scale tensors as float8_e4m3fn which would
+    # be misidentified as fp8 model weights.  Detect NVFP4 early and skip those
+    # quantization-internal keys so we return the true model dtype (bf16),
+    # mirroring the behaviour of NF4 checkpoints.
+    from musubi_tuner.modules.nvfp4_utils import detect_nvfp4_checkpoint
+    _is_nvfp4 = detect_nvfp4_checkpoint(model_path)
+
     with MemoryEfficientSafeOpen(model_path) as handle:
         keys = list(handle.keys())
         if not keys:
@@ -170,6 +177,9 @@ def detect_ltx2_dtype(model_path: str) -> torch.dtype:
 
         # Avoid loading tensors: inspect header dtype for each key.
         for key in keys:
+            # Skip NVFP4 quantization metadata keys — these are not model weights.
+            if _is_nvfp4 and (key.endswith(".weight_scale") or key.endswith(".weight_scale_2")):
+                continue
             meta = handle.header.get(key)
             if not isinstance(meta, dict) or "dtype" not in meta:
                 continue

--- a/src/musubi_tuner/ltx2_train_network.py
+++ b/src/musubi_tuner/ltx2_train_network.py
@@ -3013,9 +3013,9 @@ class LTX2NetworkTrainer(LTX2SamplingMixin, NetworkTrainer):
             logger.info("--no_convert_to_comfy is set; original LoRA is always saved (--save_original_lora has no extra effect).")
 
         if self.dit_dtype == torch.float16:
-            assert args.mixed_precision in ["fp16", "no"], "LTX-2 weights are fp16; mixed precision must be fp16 or no"
+            assert args.mixed_precision in [None, "fp16", "no"], "LTX-2 weights are fp16; mixed precision must be fp16 or no"
         elif self.dit_dtype == torch.bfloat16:
-            assert args.mixed_precision in ["bf16", "no"], "LTX-2 weights are bf16; mixed precision must be bf16 or no"
+            assert args.mixed_precision in [None, "bf16", "no"], "LTX-2 weights are bf16; mixed precision must be bf16 or no"
 
         args.dit_dtype = model_utils.dtype_to_str(self.dit_dtype)
 

--- a/src/musubi_tuner/ltx2_train_network.py
+++ b/src/musubi_tuner/ltx2_train_network.py
@@ -3424,6 +3424,8 @@ class LTX2NetworkTrainer(LTX2SamplingMixin, NetworkTrainer):
             attn_mode = "flash"
         elif args.flash3:
             attn_mode = "flash3"
+        elif getattr(args, "sage_attn", False):
+            attn_mode = "sageattn"
         elif args.xformers:
             attn_mode = "xformers"
         else:

--- a/src/musubi_tuner/ltx2_train_slider.py
+++ b/src/musubi_tuner/ltx2_train_slider.py
@@ -1319,6 +1319,14 @@ class LTX2SliderTrainer:
         else:
             transformer = accelerator.prepare(transformer)
 
+        # torch.compile the DiT blocks (mirrors LTX2NetworkTrainer in ltx2_train_network.py).
+        # Must run after prepare()/_models filtering and before the network is prepared.
+        # blocks_to_swap was set on _net_trainer above, so its disable_linear path is correct.
+        # Compilation is lazy: it triggers on the first forward pass, not here.
+        if args.compile:
+            transformer = self._net_trainer.compile_transformer(args, transformer)
+            transformer.__dict__["_orig_mod"] = transformer  # for annoying accelerator checks
+
         network, optimizer, lr_scheduler = accelerator.prepare(network, optimizer, lr_scheduler)
 
         if args.gradient_checkpointing:
@@ -1439,6 +1447,32 @@ class LTX2SliderTrainer:
             metadata["ss_sd_model_name"] = sd_model_name
 
         metadata = {k: str(v) for k, v in metadata.items()}
+
+        # User-facing SAI model-spec metadata (title/author/license/tags/etc.),
+        # embedded in saved safetensors for distribution. Mirrors the standard trainer.
+        from musubi_tuner.utils import sai_model_spec
+
+        sai_title = getattr(args, "metadata_title", None) or args.output_name
+        if getattr(args, "min_timestep", None) is not None or getattr(args, "max_timestep", None) is not None:
+            md_min = args.min_timestep if args.min_timestep is not None else 0
+            md_max = args.max_timestep if args.max_timestep is not None else 1000
+            md_timesteps = (md_min, md_max)
+        else:
+            md_timesteps = None
+        sai_metadata = sai_model_spec.build_metadata(
+            None,
+            self._net_trainer.architecture,
+            time.time(),
+            sai_title,
+            getattr(args, "metadata_reso", None),
+            getattr(args, "metadata_author", None),
+            getattr(args, "metadata_description", None),
+            getattr(args, "metadata_license", None),
+            getattr(args, "metadata_tags", None),
+            timesteps=md_timesteps,
+            custom_arch=getattr(args, "metadata_arch", None),
+        )
+        metadata.update(sai_metadata)
 
         minimum_metadata = {}
         for key in ["ss_base_model_version", "ss_network_module", "ss_network_dim", "ss_network_alpha", "ss_network_args"]:

--- a/src/musubi_tuner/ltx2_train_slider.py
+++ b/src/musubi_tuner/ltx2_train_slider.py
@@ -1115,6 +1115,7 @@ class LTX2SliderTrainer:
         if args.mixed_precision is None:
             args.mixed_precision = accelerator.mixed_precision
         is_main_process = accelerator.is_main_process
+        dashboard_metrics_enabled = getattr(args, "gui", False) or os.getenv("MUSUBI_DASHBOARD_METRICS") == "1"
 
         # Precision
         dit_dtype = torch.bfloat16 if args.dit_dtype is None else model_utils.str_to_dtype(args.dit_dtype)
@@ -1403,6 +1404,20 @@ class LTX2SliderTrainer:
                 init_kwargs=init_kwargs,
             )
 
+        # -- Dashboard metrics writer (Parquet for GUI charts) -----------------
+        gui_metrics = None
+        if dashboard_metrics_enabled and accelerator.is_main_process:
+            from musubi_tuner.gui_dashboard import create_metrics_writer
+
+            gui_metrics = create_metrics_writer(args.output_dir, reset=initial_global_step == 0)
+            gui_metrics.update_status(
+                step=initial_global_step,
+                max_steps=args.max_train_steps,
+                epoch=0,
+                max_epochs=0,
+                status="starting",
+            )
+
         # -- Save / remove helpers ---------------------------------------------
         save_dtype = dit_dtype
 
@@ -1456,6 +1471,17 @@ class LTX2SliderTrainer:
                     os.remove(comfy_old_ckpt_file)
             train_utils.remove_checkpoint_metadata(old_ckpt_file)
 
+        def _close_gui_metrics(status: str = "stopped"):
+            if gui_metrics is not None:
+                gui_metrics.update_status(
+                    step=global_step,
+                    max_steps=args.max_train_steps,
+                    epoch=0,
+                    max_epochs=0,
+                    status=status,
+                )
+                gui_metrics.close()
+
         def handle_dashboard_stop_request(global_step: int) -> bool:
             if not train_utils.dashboard_stop_requested():
                 return False
@@ -1463,12 +1489,14 @@ class LTX2SliderTrainer:
             if train_utils.dashboard_stop_mode() == "force":
                 accelerator.print("\nDashboard force stop requested; exiting without saving interrupt state.")
                 train_utils.clear_dashboard_stop_request()
+                _close_gui_metrics("stopped")
                 accelerator.end_training()
                 return True
 
             if global_step <= 0:
                 accelerator.print("\nDashboard stop requested before training steps completed; exiting without saving state.")
                 train_utils.clear_dashboard_stop_request()
+                _close_gui_metrics("stopped")
                 accelerator.end_training()
                 return True
 
@@ -1491,7 +1519,10 @@ class LTX2SliderTrainer:
                         "interrupted": True,
                     },
                 )
+                if gui_metrics is not None:
+                    gui_metrics.log_event("interrupt_state", global_step, path=str(state_dir))
             train_utils.clear_dashboard_stop_request()
+            _close_gui_metrics("stopped")
             accelerator.end_training()
             return True
 
@@ -1532,6 +1563,8 @@ class LTX2SliderTrainer:
             self._sample_slider(
                 accelerator, args, transformer, vae, accelerator.unwrap_model(network), sample_parameters, dit_dtype, 0
             )
+            if gui_metrics is not None:
+                gui_metrics.log_event("sample", 0)
             optimizer_train_fn()
 
         ref_iter = None
@@ -1543,6 +1576,9 @@ class LTX2SliderTrainer:
                 return
 
             accelerator.unwrap_model(network).on_step_start()
+
+            grad_norm_value = None
+            _step_start_time = time.perf_counter()
 
             with accelerator.accumulate(network):
                 if self.slider_config.mode == "text":
@@ -1564,7 +1600,7 @@ class LTX2SliderTrainer:
                 # Gradient clipping
                 if accelerator.sync_gradients and getattr(args, "max_grad_norm", 0.0) != 0.0:
                     params_to_clip = accelerator.unwrap_model(network).get_trainable_params()
-                    accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
+                    grad_norm_value = accelerator.clip_grad_norm_(params_to_clip, args.max_grad_norm)
 
                 if accelerator.sync_gradients:
                     optimizer.step()
@@ -1590,7 +1626,28 @@ class LTX2SliderTrainer:
                     "loss/average": avr_loss,
                     "lr/unet": float(lrs[0]) if lrs else 0.0,
                 }
+                if grad_norm_value is not None:
+                    logs["grad_norm"] = float(grad_norm_value) if not isinstance(grad_norm_value, float) else grad_norm_value
                 accelerator.log(logs, step=global_step)
+
+            if gui_metrics is not None:
+                step_time = time.perf_counter() - _step_start_time
+                gui_metrics.log(
+                    step=global_step,
+                    epoch=0,
+                    loss=loss,
+                    avr_loss=avr_loss,
+                    grad_norm=float(grad_norm_value) if grad_norm_value is not None else None,
+                    lr=float(lr_scheduler.get_last_lr()[0]) if lr_scheduler.get_last_lr() else 0.0,
+                    step_time=step_time,
+                )
+                gui_metrics.update_status(
+                    step=global_step,
+                    max_steps=args.max_train_steps,
+                    epoch=0,
+                    max_epochs=0,
+                    status="training",
+                )
 
             # Sampling
             should_sampling = should_sample_images(args, global_step, epoch=None)
@@ -1610,12 +1667,16 @@ class LTX2SliderTrainer:
                         dit_dtype,
                         global_step,
                     )
+                    if gui_metrics is not None:
+                        gui_metrics.log_event("sample", global_step)
 
                 if should_saving:
                     accelerator.wait_for_everyone()
                     if accelerator.is_main_process:
                         ckpt_name = train_utils.get_step_ckpt_name(args.output_name, global_step)
                         save_model(ckpt_name, accelerator.unwrap_model(network), global_step, 0)
+                        if gui_metrics is not None:
+                            gui_metrics.log_event("checkpoint", global_step)
 
                         if getattr(args, "save_state", False):
                             train_utils.save_and_remove_state_stepwise(
@@ -1642,7 +1703,11 @@ class LTX2SliderTrainer:
         if is_main_process:
             ckpt_name = train_utils.get_last_ckpt_name(args.output_name)
             save_model(ckpt_name, accelerator.unwrap_model(network), global_step, 0, force_sync_upload=True)
+            if gui_metrics is not None:
+                gui_metrics.log_event("checkpoint", global_step)
             logger.info("Slider training complete. Model saved.")
+
+        _close_gui_metrics("completed")
 
 
 # ---------------------------------------------------------------------------

--- a/src/musubi_tuner/ltx2_train_slider.py
+++ b/src/musubi_tuner/ltx2_train_slider.py
@@ -1308,6 +1308,14 @@ class LTX2SliderTrainer:
 
         lr_scheduler = NetworkTrainer().get_lr_scheduler(args, optimizer, accelerator.num_processes)
 
+        # Save base param_groups (from CLI) before any resume so we can restore them
+        # if --reset_optimizer_params is set. Mirrors NetworkTrainer.train(); the
+        # slider has its own loop and must replicate this resume-time behavior.
+        inner_optimizer = optimizer.optimizer if hasattr(optimizer, "optimizer") else optimizer
+        saved_param_groups = None
+        if getattr(args, "reset_optimizer_params", False):
+            saved_param_groups = [{k: v for k, v in pg.items() if k != "params"} for pg in inner_optimizer.param_groups]
+
         # -- Prepare with accelerator ------------------------------------------
         if dit_weight_dtype != dit_dtype and dit_weight_dtype is not None:
             transformer.to(dit_weight_dtype)
@@ -1373,6 +1381,37 @@ class LTX2SliderTrainer:
             if resume_step > 0:
                 initial_global_step = resume_step
                 logger.info(f"Recovered global_step={initial_global_step} from resume state")
+
+            # Optimizer/scheduler resets after a state-dir resume (mirrors
+            # NetworkTrainer.train()). Only meaningful when optimizer state was
+            # actually loaded (initial_global_step > 0); the weights-only fallback
+            # below re-initializes the optimizer anyway.
+            if initial_global_step > 0:
+                if getattr(args, "reset_optimizer", False):
+                    inner_optimizer.state.clear()
+                    accelerator.print("reset optimizer state (cleared momentum/variance)")
+
+                if getattr(args, "reset_optimizer_params", False) and saved_param_groups is not None:
+                    for pg, saved in zip(inner_optimizer.param_groups, saved_param_groups):
+                        for k, v in saved.items():
+                            pg[k] = v
+                    accelerator.print("reset optimizer param groups to CLI values")
+
+                if getattr(args, "reset_optimizer", False) or getattr(args, "reset_optimizer_params", False):
+                    # reset lr to base value so the new scheduler starts from the correct base
+                    # (scheduler __init__ uses current group['lr'], not initial_lr)
+                    for pg in inner_optimizer.param_groups:
+                        if "initial_lr" in pg:
+                            pg["lr"] = pg["initial_lr"]
+                            del pg["initial_lr"]
+                    new_inner_scheduler = NetworkTrainer().get_lr_scheduler(args, inner_optimizer, accelerator.num_processes)
+                    # replace the inner scheduler while keeping the AcceleratedScheduler wrapper
+                    # (the wrapper gates stepping on sync_gradients for gradient accumulation)
+                    if hasattr(lr_scheduler, "scheduler"):
+                        lr_scheduler.scheduler = new_inner_scheduler
+                    else:
+                        lr_scheduler = new_inner_scheduler
+                    accelerator.print("recreated LR scheduler (restarting schedule from step 0)")
 
         # -- Fallback: resume from latest LoRA checkpoint if no state dir ------
         # If autoresume is enabled but no state directory was found (e.g. crash
@@ -1707,6 +1746,14 @@ class LTX2SliderTrainer:
                     optimizer.step()
                     lr_scheduler.step()
                     optimizer.zero_grad(set_to_none=True)
+
+                    # LoRA max-norm regularization (mirrors hv_train_network.py).
+                    # The slider has its own loop, so this must be applied here;
+                    # the network method self-guards for non-LoRA networks.
+                    if getattr(args, "scale_weight_norms", None):
+                        accelerator.unwrap_model(network).apply_max_norm_regularization(
+                            args.scale_weight_norms, accelerator.device
+                        )
 
             if not accelerator.sync_gradients:
                 continue

--- a/src/musubi_tuner/ltx2_train_slider.py
+++ b/src/musubi_tuner/ltx2_train_slider.py
@@ -89,10 +89,25 @@ class SliderTargetConfig:
 
 
 @dataclass
+class SliderAnchorConfig:
+    """A concept to preserve (text-mode only).
+
+    At both slider multipliers (+1 and -1) the LoRA's prediction for the anchor
+    prompt is constrained (MSE) to match the frozen base model's prediction,
+    preventing the slider from drifting on unrelated concepts.
+    """
+
+    prompt: str
+
+
+@dataclass
 class SliderConfig:
     mode: str  # "text", "reference", or "ic_reference"
     reference_modality: str = "video"  # "video" or "audio" for reference mode
     targets: List[SliderTargetConfig] = field(default_factory=list)
+    anchors: List[SliderAnchorConfig] = field(default_factory=list)  # text-mode preservation
+    anchor_strength: float = 1.0  # weight on the anchor preservation loss (text-mode only)
+    anchor_cap_mult: float = 5.0  # cap per-step anchor loss at this x running median (0=off)
     guidance_strength: float = 1.0
     frame_rate: int = 25
     sample_slider_range: List[float] = field(default_factory=lambda: [-2.0, -1.0, 0.0, 1.0, 2.0])
@@ -110,6 +125,8 @@ def load_slider_config(path: str) -> SliderConfig:
     mode = raw.get("mode", "text")
     reference_modality = str(raw.get("reference_modality", "video")).lower()
     guidance_strength = float(raw.get("guidance_strength", 1.0))
+    anchor_strength = float(raw.get("anchor_strength", 1.0))
+    anchor_cap_mult = float(raw.get("anchor_cap_mult", 5.0))
     frame_rate = int(raw.get("frame_rate", 25))
     default_slider_range = [-2.0, -1.0, 0.0, 1.0, 2.0]
     sample_slider_range = raw.get("sample_slider_range", default_slider_range)
@@ -133,6 +150,10 @@ def load_slider_config(path: str) -> SliderConfig:
             )
         )
 
+    anchors = []
+    for a in raw.get("anchors", []):
+        anchors.append(SliderAnchorConfig(prompt=a["prompt"]))
+
     pos_cache_dir = raw.get("pos_cache_dir", None)
     neg_cache_dir = raw.get("neg_cache_dir", None)
     text_cache_dir = raw.get("text_cache_dir", None) or pos_cache_dir
@@ -142,6 +163,9 @@ def load_slider_config(path: str) -> SliderConfig:
         mode=mode,
         reference_modality=reference_modality,
         targets=targets,
+        anchors=anchors,
+        anchor_strength=anchor_strength,
+        anchor_cap_mult=anchor_cap_mult,
         guidance_strength=guidance_strength,
         frame_rate=frame_rate,
         sample_slider_range=[float(v) for v in sample_slider_range],
@@ -165,6 +189,24 @@ def _norm_like_tensor(tensor: torch.Tensor, target: torch.Tensor) -> torch.Tenso
     (Ported from ai-toolkit ConceptSliderTrainer.)
     """
     return (tensor - tensor.mean()) / (tensor.std() + 1e-8) * target.std() + target.mean()
+
+
+def _anchor_mse(lora_pred: torch.Tensor, base_pred: torch.Tensor) -> torch.Tensor:
+    """Raw MSE between LoRA and frozen-base anchor predictions (velocity space).
+
+    The per-step magnitude of this loss is intrinsically spiky: on ~90% of steps
+    the LoRA barely moves the anchor prediction (loss ~1e-4), but on a small
+    fraction of steps it deviates a lot. An offline probe over real predictions
+    showed this spikiness is NOT a removable per-step scale factor — every
+    per-step normalizer tried (variance-normalize, cosine, relative-MSE) left a
+    1000x-7000x dynamic range, because the variation lives in the genuine
+    deviation (the numerator), not in a divisible scale. The robust fix is to
+    *cap* the per-step contribution (see ``_anchor_loss``), which bounds the
+    rare spikes while leaving the typical steps untouched. This mirrors the
+    spirit of Min-SNR-gamma clamping.
+    """
+    diff = lora_pred.float() - base_pred.float()
+    return (diff * diff).mean()
 
 
 def _pad_and_batch(
@@ -402,6 +444,7 @@ class LTX2SliderTrainer:
         self._net_trainer = LTX2NetworkTrainer()
         self.slider_config: Optional[SliderConfig] = None
         self.cached_embeds: Dict[str, Tuple[torch.Tensor, torch.Tensor]] = {}
+        self._anchor_running_median: Optional[float] = None  # for spike capping
 
     def _prepare_first_frame_conditioning(
         self,
@@ -509,6 +552,8 @@ class LTX2SliderTrainer:
             prompts.add(target.positive)
             prompts.add(target.negative)
             prompts.add(target.target_class)
+        for anchor in self.slider_config.anchors:
+            prompts.add(anchor.prompt)
         prompts.add("")  # neutral / empty prompt
 
         for prompt_text in prompts:
@@ -571,27 +616,41 @@ class LTX2SliderTrainer:
         neu_e, neu_m = self.cached_embeds[""]
         tgt_e, tgt_m = self.cached_embeds[target.target_class]
 
-        # Pad and batch for 3-pass: [positive, neutral, negative]
-        text_3x, mask_3x = _pad_and_batch([(pos_e, pos_m), (neu_e, neu_m), (neg_e, neg_m)], device, dit_dtype)
+        # Anchors (text-mode preservation). Each anchor's frozen-base prediction
+        # becomes a target that the LoRA must match at BOTH multipliers (+1 / -1),
+        # so the slider does not drift on these unrelated concepts.
+        anchors = self.slider_config.anchors
+        n_anchors = len(anchors)
+        anchor_strength = self.slider_config.anchor_strength
+        anchor_items = [self.cached_embeds[a.prompt] for a in anchors]
 
-        # No-grad 3-pass forward (LoRA disabled)
+        # Pad and batch the no-grad reference pass:
+        #   [positive, neutral, negative, anchor_0..N]
+        ref_items = [(pos_e, pos_m), (neu_e, neu_m), (neg_e, neg_m)] + anchor_items
+        num_ref = 3 + n_anchors
+        text_ref, mask_ref = _pad_and_batch(ref_items, device, dit_dtype)
+
+        # No-grad forward (LoRA disabled)
         network.set_multiplier(0.0)
-        noisy_3x = noisy.expand(3, -1, -1, -1, -1).to(dtype=dit_dtype)
-        ts_3x = model_ts.expand(3, -1)
+        noisy_ref = noisy.expand(num_ref, -1, -1, -1, -1).to(dtype=dit_dtype)
+        ts_ref = model_ts.expand(num_ref, -1)
 
         with torch.no_grad():
             self._net_trainer._ensure_fp8_buffers_on_device(accelerator.unwrap_model(transformer))
             with accelerator.autocast():
-                pred_3x = transformer(
-                    noisy_3x,
-                    timestep=ts_3x,
-                    context=text_3x,
-                    attention_mask=mask_3x,
+                pred_ref = transformer(
+                    noisy_ref,
+                    timestep=ts_ref,
+                    context=text_ref,
+                    attention_mask=mask_ref,
                     frame_rate=self.slider_config.frame_rate,
                     transformer_options={},
                 )
 
-        pred_pos, pred_neu, pred_neg = pred_3x.chunk(3, dim=0)
+        ref_chunks = pred_ref.chunk(num_ref, dim=0)
+        pred_pos, pred_neu, pred_neg = ref_chunks[0], ref_chunks[1], ref_chunks[2]
+        # Frozen-base anchor predictions (detached) — the preservation targets.
+        anchor_targets = [c.detach() for c in ref_chunks[3:]]
 
         # Compute directional offset
         direction = pred_pos - pred_neg
@@ -599,25 +658,85 @@ class LTX2SliderTrainer:
         target_enhance = _norm_like_tensor(pred_neu + gs * direction, pred_neu).detach()
         target_erase = _norm_like_tensor(pred_neu - gs * direction, pred_neu).detach()
 
-        del pred_3x, noisy_3x, ts_3x, text_3x, mask_3x, pred_pos, pred_neu, pred_neg, direction
+        del pred_ref, noisy_ref, ts_ref, text_ref, mask_ref, pred_pos, pred_neu, pred_neg, direction
         clean_memory_on_device(device)
 
-        # Prepare target_class embeddings for training passes
-        tgt_text, tgt_mask = _pad_and_batch([(tgt_e, tgt_m)], device, dit_dtype)
+        # Prepare conditioning for the gradient passes:
+        #   [target_class, anchor_0..N]  (anchors share the same noisy latent)
+        grad_items = [(tgt_e, tgt_m)] + anchor_items
+        num_grad = 1 + n_anchors
+        grad_text, grad_mask = _pad_and_batch(grad_items, device, dit_dtype)
         noisy_dit = noisy.to(dtype=dit_dtype)
+        noisy_grad = noisy_dit.expand(num_grad, -1, -1, -1, -1) if n_anchors > 0 else noisy_dit
+        ts_grad = model_ts.expand(num_grad, -1) if n_anchors > 0 else model_ts
+
+        def _anchor_loss(pred_chunks) -> torch.Tensor:
+            """Anchor preservation loss with running-median spike capping.
+
+            Per-step anchor MSE is intrinsically spiky (most steps ~1e-4, a few
+            steps far larger) and no per-step normalizer removes that (verified
+            by offline probe). We instead cap each step's anchor loss at a
+            multiple of its running median, which bounds the rare gradient-norm
+            spikes while leaving typical steps untouched. The cap is applied in
+            a gradient-preserving way (scale the loss tensor by a detached ratio)
+            so the optimizer still moves in the anchor's direction, just not with
+            an explosive magnitude.
+            """
+            if n_anchors == 0:
+                return None
+            losses = [
+                _anchor_mse(pred_chunks[i + 1], anchor_targets[i])
+                for i in range(n_anchors)
+            ]
+            anchor = sum(losses) / n_anchors
+
+            # Running-median cap (self-calibrating, no model-specific constant).
+            cap_mult = self.slider_config.anchor_cap_mult
+            val = float(anchor.detach().item())
+            med = self._anchor_running_median
+            if med is not None and cap_mult > 0:
+                cap = med * cap_mult
+                if val > cap and val > 0:
+                    # Scale the (grad-bearing) loss down to the cap. Ratio is
+                    # detached so only magnitude is clipped, not direction.
+                    anchor = anchor * (cap / val)
+            # Update running median estimate with the UNCAPPED value via a simple
+            # exponential tracker toward the observed value (robust enough for a
+            # cap reference; not a true median but tracks the typical scale).
+            if med is None:
+                self._anchor_running_median = val
+            else:
+                # Move 2% toward current; downweight giant spikes so they don't
+                # inflate the cap reference.
+                step = 0.02 if val <= med * cap_mult else 0.002
+                self._anchor_running_median = med + step * (val - med)
+
+            return anchor * anchor_strength
 
         # Training pass 1: positive direction (multiplier=+1)
         network.set_multiplier(1.0)
         with accelerator.autocast():
             lora_pred_pos = transformer(
-                noisy_dit,
-                timestep=model_ts,
-                context=tgt_text,
-                attention_mask=tgt_mask,
+                noisy_grad,
+                timestep=ts_grad,
+                context=grad_text,
+                attention_mask=grad_mask,
                 frame_rate=self.slider_config.frame_rate,
                 transformer_options={},
             )
-        loss_pos = F_torch.mse_loss(lora_pred_pos.float(), target_enhance.float())
+        # Keep the direction loss and the anchor loss as SEPARATE quantities for
+        # reporting (loss/average stays direction-only, loss/anchor is its own
+        # series). The backward pass still uses their sum, so training behaviour
+        # is unchanged — only what we report is split.
+        if n_anchors > 0:
+            pos_chunks = lora_pred_pos.chunk(num_grad, dim=0)
+            class_pred_pos = pos_chunks[0]
+            dir_pos = F_torch.mse_loss(class_pred_pos.float(), target_enhance.float())
+            anc_pos = _anchor_loss(pos_chunks)
+        else:
+            dir_pos = F_torch.mse_loss(lora_pred_pos.float(), target_enhance.float())
+            anc_pos = None
+        loss_pos = dir_pos if anc_pos is None else (dir_pos + anc_pos)
         accelerator.backward(loss_pos * target.weight)
 
         del lora_pred_pos
@@ -627,22 +746,38 @@ class LTX2SliderTrainer:
         network.set_multiplier(-1.0)
         with accelerator.autocast():
             lora_pred_neg = transformer(
-                noisy_dit,
-                timestep=model_ts,
-                context=tgt_text,
-                attention_mask=tgt_mask,
+                noisy_grad,
+                timestep=ts_grad,
+                context=grad_text,
+                attention_mask=grad_mask,
                 frame_rate=self.slider_config.frame_rate,
                 transformer_options={},
             )
-        loss_neg = F_torch.mse_loss(lora_pred_neg.float(), target_erase.float())
+        if n_anchors > 0:
+            neg_chunks = lora_pred_neg.chunk(num_grad, dim=0)
+            class_pred_neg = neg_chunks[0]
+            dir_neg = F_torch.mse_loss(class_pred_neg.float(), target_erase.float())
+            anc_neg = _anchor_loss(neg_chunks)
+        else:
+            dir_neg = F_torch.mse_loss(lora_pred_neg.float(), target_erase.float())
+            anc_neg = None
+        loss_neg = dir_neg if anc_neg is None else (dir_neg + anc_neg)
         accelerator.backward(loss_neg * target.weight)
 
-        del lora_pred_neg, noisy_dit, tgt_text, tgt_mask
+        del lora_pred_neg, noisy_dit, noisy_grad, ts_grad, grad_text, grad_mask
         clean_memory_on_device(device)
 
         # Restore multiplier
         network.set_multiplier(1.0)
-        return (loss_pos.item() + loss_neg.item()) / 2.0
+
+        # loss/average == direction only (same meaning as before anchors existed).
+        direction_avg = (dir_pos.item() + dir_neg.item()) / 2.0
+        # loss/anchor == anchor term only; None when no anchors are configured.
+        if n_anchors > 0:
+            anchor_avg = (anc_pos.item() + anc_neg.item()) / 2.0
+        else:
+            anchor_avg = None
+        return direction_avg, anchor_avg
 
     # -- Reference-based slider step -----------------------------------------
 
@@ -1482,6 +1617,9 @@ class LTX2SliderTrainer:
             "ss_slider_mode": self.slider_config.mode,
             "ss_slider_guidance_strength": self.slider_config.guidance_strength,
         }
+        if self.slider_config.mode == "text" and len(self.slider_config.anchors) > 0:
+            metadata["ss_slider_anchor_count"] = len(self.slider_config.anchors)
+            metadata["ss_slider_anchor_strength"] = self.slider_config.anchor_strength
         if self.slider_config.mode == "ic_reference":
             metadata["ss_ic_lora_strategy"] = "v2v"
             metadata["ss_slider_ic_reference_training"] = True
@@ -1731,9 +1869,13 @@ class LTX2SliderTrainer:
             grad_norm_value = None
             _step_start_time = time.perf_counter()
 
+            anchor_loss = None  # populated only in text mode when anchors are configured
             with accelerator.accumulate(network):
                 if self.slider_config.mode == "text":
-                    loss = self._text_slider_step(transformer, network, accelerator, args, dit_dtype)
+                    # Text mode returns (direction_loss, anchor_loss). loss/average
+                    # tracks the direction loss only (unchanged meaning); anchor_loss
+                    # is reported separately as loss/anchor.
+                    loss, anchor_loss = self._text_slider_step(transformer, network, accelerator, args, dit_dtype)
                 else:
                     # Reference mode: get next batch
                     try:
@@ -1787,6 +1929,8 @@ class LTX2SliderTrainer:
                 }
                 if grad_norm_value is not None:
                     logs["grad_norm"] = float(grad_norm_value) if not isinstance(grad_norm_value, float) else grad_norm_value
+                if anchor_loss is not None:
+                    logs["loss/anchor"] = anchor_loss
                 accelerator.log(logs, step=global_step)
 
             if gui_metrics is not None:

--- a/src/musubi_tuner/ltx2_train_slider.py
+++ b/src/musubi_tuner/ltx2_train_slider.py
@@ -108,6 +108,7 @@ class SliderConfig:
     anchors: List[SliderAnchorConfig] = field(default_factory=list)  # text-mode preservation
     anchor_strength: float = 1.0  # weight on the anchor preservation loss (text-mode only)
     anchor_cap_mult: float = 5.0  # cap per-step anchor loss at this x running median (0=off)
+    batch_all_targets: bool = False  # text-mode: process ALL targets per step (avg) vs one random
     guidance_strength: float = 1.0
     frame_rate: int = 25
     sample_slider_range: List[float] = field(default_factory=lambda: [-2.0, -1.0, 0.0, 1.0, 2.0])
@@ -127,6 +128,7 @@ def load_slider_config(path: str) -> SliderConfig:
     guidance_strength = float(raw.get("guidance_strength", 1.0))
     anchor_strength = float(raw.get("anchor_strength", 1.0))
     anchor_cap_mult = float(raw.get("anchor_cap_mult", 5.0))
+    batch_all_targets = bool(raw.get("batch_all_targets", False))
     frame_rate = int(raw.get("frame_rate", 25))
     default_slider_range = [-2.0, -1.0, 0.0, 1.0, 2.0]
     sample_slider_range = raw.get("sample_slider_range", default_slider_range)
@@ -166,6 +168,7 @@ def load_slider_config(path: str) -> SliderConfig:
         anchors=anchors,
         anchor_strength=anchor_strength,
         anchor_cap_mult=anchor_cap_mult,
+        batch_all_targets=batch_all_targets,
         guidance_strength=guidance_strength,
         frame_rate=frame_rate,
         sample_slider_range=[float(v) for v in sample_slider_range],
@@ -574,10 +577,63 @@ class LTX2SliderTrainer:
         args: argparse.Namespace,
         dit_dtype: torch.dtype,
     ) -> float:
-        """One training step for text-only slider mode."""
+        """One training step for text-only slider mode.
+
+        By default a single target is picked at random per step. When
+        ``batch_all_targets`` is enabled, EVERY target is processed in the same
+        step and their gradients are averaged (each target's loss scaled by
+        1/N) into a single optimizer update. This yields a lower-variance,
+        more context-general direction (the shared signal across targets
+        reinforces, context-specific noise partially cancels) at ~N x the
+        per-step cost. The anchor loss, when present, is scaled by the same
+        1/N so anchor magnitude/behaviour is identical to the non-batched path.
+        """
         device = accelerator.device
 
-        target = random.choice(self.slider_config.targets)
+        targets = self.slider_config.targets
+        if self.slider_config.batch_all_targets and len(targets) > 0:
+            n_targets = len(targets)
+            loss_scale = 1.0 / n_targets
+            dir_sum = 0.0
+            anc_sum = 0.0
+            anc_count = 0
+            for tgt in targets:
+                d, a = self._run_one_text_target(
+                    transformer, network, accelerator, args, dit_dtype, tgt, loss_scale
+                )
+                dir_sum += d
+                if a is not None:
+                    anc_sum += a
+                    anc_count += 1
+            direction_avg = dir_sum / n_targets
+            anchor_avg = (anc_sum / anc_count) if anc_count > 0 else None
+            return direction_avg, anchor_avg
+
+        target = random.choice(targets)
+        return self._run_one_text_target(
+            transformer, network, accelerator, args, dit_dtype, target, 1.0
+        )
+
+    def _run_one_text_target(
+        self,
+        transformer,
+        network,
+        accelerator: Accelerator,
+        args: argparse.Namespace,
+        dit_dtype: torch.dtype,
+        target: "SliderTargetConfig",
+        loss_scale: float,
+    ) -> Tuple[float, Optional[float]]:
+        """Process one slider target: +1/-1 gradient passes for ``target``.
+
+        ``loss_scale`` multiplies the backward loss (1.0 for the single-random
+        path; 1/N when averaging all targets in one step). Returns
+        ``(direction_avg, anchor_avg)`` for this target (anchor_avg is None when
+        no anchors are configured). The reported direction/anchor values are the
+        UNSCALED averages so loss/average keeps its meaning regardless of
+        loss_scale.
+        """
+        device = accelerator.device
 
         # Synthetic noise latents
         latent_frames = getattr(args, "latent_frames", 1)
@@ -737,7 +793,7 @@ class LTX2SliderTrainer:
             dir_pos = F_torch.mse_loss(lora_pred_pos.float(), target_enhance.float())
             anc_pos = None
         loss_pos = dir_pos if anc_pos is None else (dir_pos + anc_pos)
-        accelerator.backward(loss_pos * target.weight)
+        accelerator.backward(loss_pos * target.weight * loss_scale)
 
         del lora_pred_pos
         clean_memory_on_device(device)
@@ -762,7 +818,7 @@ class LTX2SliderTrainer:
             dir_neg = F_torch.mse_loss(lora_pred_neg.float(), target_erase.float())
             anc_neg = None
         loss_neg = dir_neg if anc_neg is None else (dir_neg + anc_neg)
-        accelerator.backward(loss_neg * target.weight)
+        accelerator.backward(loss_neg * target.weight * loss_scale)
 
         del lora_pred_neg, noisy_dit, noisy_grad, ts_grad, grad_text, grad_mask
         clean_memory_on_device(device)

--- a/src/musubi_tuner/ltx2_train_slider.py
+++ b/src/musubi_tuner/ltx2_train_slider.py
@@ -1319,6 +1319,13 @@ class LTX2SliderTrainer:
         else:
             transformer = accelerator.prepare(transformer)
 
+        # The frozen base transformer was added to accelerator._models by prepare(),
+        # which means save_state() would serialize it (~13 GB) even though its weights
+        # never change during LoRA/slider training.  Remove it so only the LoRA
+        # network (prepared below) is included in state checkpoints.
+        _unwrapped_transformer = accelerator.unwrap_model(transformer)
+        accelerator._models = [m for m in accelerator._models if accelerator.unwrap_model(m) is not _unwrapped_transformer]
+
         # torch.compile the DiT blocks (mirrors LTX2NetworkTrainer in ltx2_train_network.py).
         # Must run after prepare()/_models filtering and before the network is prepared.
         # blocks_to_swap was set on _net_trainer above, so its disable_linear path is correct.

--- a/src/musubi_tuner/ltx2_train_slider.py
+++ b/src/musubi_tuner/ltx2_train_slider.py
@@ -16,7 +16,7 @@ import re
 import random
 import sys
 import time
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Dict, List, Optional, Tuple
 
 import toml
@@ -43,6 +43,36 @@ from musubi_tuner.training.parser_common import read_config_from_file, setup_par
 from musubi_tuner.training.sampling_prompts import should_sample_images
 from musubi_tuner.training.trainer_base import NetworkTrainer
 from musubi_tuner.utils import model_utils, train_utils
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _argv_to_command_list() -> list:
+    """Group ``sys.argv`` into ``[flag, value]`` pairs for JSON metadata.
+
+    Boolean flags (``--gradient_checkpointing``) become single-element lists.
+    Flags with values (``--learning_rate 0.0002``) become two-element lists.
+    Positional tokens (script path) become single-element lists.
+    """
+    result: list[list[str]] = []
+    argv = sys.argv
+    i = 0
+    while i < len(argv):
+        token = argv[i]
+        if token.startswith("--"):
+            if i + 1 < len(argv) and not argv[i + 1].startswith("--"):
+                result.append([token, argv[i + 1]])
+                i += 2
+            else:
+                result.append([token])
+                i += 1
+        else:
+            result.append([token])
+            i += 1
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -1397,7 +1427,7 @@ class LTX2SliderTrainer:
                 init_kwargs["wandb"] = {"name": args.wandb_run_name}
             if getattr(args, "log_tracker_config", None) is not None:
                 init_kwargs = toml.load(args.log_tracker_config)
-            tracker_name = getattr(args, "log_tracker_name", None) or "slider_train"
+            tracker_name = getattr(args, "log_tracker_name", None) or getattr(args, "output_name", "slider_train")
             accelerator.init_trackers(
                 tracker_name,
                 config=train_utils.get_sanitized_config_or_none(args),
@@ -1442,21 +1472,26 @@ class LTX2SliderTrainer:
             if getattr(args, "save_checkpoint_metadata", False):
                 from datetime import datetime
 
-                _md = {
+                _training = {
                     "step": steps,
                     "epoch": epoch_no,
                     "timestamp": datetime.now().isoformat(timespec="seconds"),
                 }
                 try:
-                    _md["loss"] = float(loss)
+                    _training["loss"] = float(loss)
                 except Exception:
                     pass
                 if loss_recorder.loss_list:
-                    _md["loss_avg"] = loss_recorder.moving_average
+                    _training["loss_avg"] = loss_recorder.moving_average
                 try:
-                    _md["lr"] = float(lr_scheduler.get_last_lr()[0])
+                    _training["lr"] = float(lr_scheduler.get_last_lr()[0])
                 except Exception:
                     pass
+                _md = {
+                    "training": _training,
+                    "command": _argv_to_command_list(),
+                    "slider_config": asdict(self.slider_config),
+                }
                 train_utils.save_checkpoint_metadata(ckpt_file, _md)
 
         def remove_model(old_ckpt_name):

--- a/src/musubi_tuner/ltx2_train_slider.py
+++ b/src/musubi_tuner/ltx2_train_slider.py
@@ -1771,6 +1771,15 @@ class LTX2SliderTrainer:
                 _training["lr"] = float(lr_scheduler.get_last_lr()[0])
             except Exception:
                 pass
+            # Smoothed seconds-per-step (s/it) from the dashboard metrics writer's
+            # rolling window. Omitted when the writer is disabled (CLI-only runs).
+            if gui_metrics is not None:
+                _sec = gui_metrics.current_sec_per_step()
+                if _sec is not None:
+                    _training["sec_per_step"] = round(_sec, 4)
+                _elapsed = gui_metrics.current_elapsed_sec()
+                if _elapsed is not None:
+                    _training["elapsed_sec"] = round(_elapsed, 1)
             return {
                 "training": _training,
                 "command": _argv_to_command_list(),

--- a/src/musubi_tuner/ltx2_train_slider.py
+++ b/src/musubi_tuner/ltx2_train_slider.py
@@ -559,8 +559,11 @@ class LTX2SliderTrainer:
         sigma_exp = sigma.view(1, 1, 1, 1, 1)
         noisy = sigma_exp * noise  # pure noise scaled by sigma
 
-        # Timestep for model: sigma as [B, 1]
-        model_ts = sigma.unsqueeze(1)
+        # Timestep for model: sigma as [B, 1]. Cast to dit_dtype so attention
+        # backends that require fp16/bf16 inputs (SageAttention, FlashAttention3)
+        # receive matching-precision hidden states. Mirrors call_dit in the
+        # standard trainer, which casts timesteps to network_dtype.
+        model_ts = sigma.unsqueeze(1).to(dtype=dit_dtype)
 
         # Get cached embeddings
         pos_e, pos_m = self.cached_embeds[target.positive]
@@ -689,7 +692,8 @@ class LTX2SliderTrainer:
         # Create noisy versions (flow matching interpolation)
         noisy_pos = ((1.0 - sigma_exp) * pos_latents + sigma_exp * noise).to(dtype=dit_dtype)
         noisy_neg = ((1.0 - sigma_exp) * neg_latents + sigma_exp * noise).to(dtype=dit_dtype)
-        model_ts = sigma.unsqueeze(1)
+        # Cast timestep to dit_dtype for fp16/bf16-only attention backends (see text step).
+        model_ts = sigma.unsqueeze(1).to(dtype=dit_dtype)
 
         # Flow matching velocity targets
         target_pos = (noise - pos_latents).to(dtype=dit_dtype)
@@ -935,7 +939,9 @@ class LTX2SliderTrainer:
         sigma_exp = sigma.view(-1, 1, 1, 1, 1)
         noisy_pos = ((1.0 - sigma_exp) * pos_latents + sigma_exp * noise).to(dtype=dit_dtype)
         noisy_neg = ((1.0 - sigma_exp) * neg_latents + sigma_exp * noise).to(dtype=dit_dtype)
-        model_ts = sigma.unsqueeze(1)
+        # call_dit casts timesteps to network_dtype internally, but cast here too
+        # for consistency with the other slider paths.
+        model_ts = sigma.unsqueeze(1).to(dtype=dit_dtype)
 
         ic_batch = {
             "text": text_embeds,
@@ -1137,13 +1143,19 @@ class LTX2SliderTrainer:
         session_id = random.randint(0, 2**32)
         training_started_at = time.time()
 
-        # Model-specific init (sets _ltx_mode, _audio_video, etc.)
-        self._net_trainer.handle_model_specific_args(args)
-
-        # Prepare accelerator
+        # Prepare accelerator FIRST so args.mixed_precision is resolved before
+        # handle_model_specific_args runs. handle_model_specific_args casts an
+        # fp32 checkpoint's compute dtype to bf16/fp16, but only when
+        # args.mixed_precision is already set — otherwise dit_dtype stays fp32
+        # and the model loads/computes in full fp32 (slower, more VRAM, and
+        # incompatible with fp16/bf16-only attention backends like SageAttention).
         accelerator = prepare_accelerator(args)
         if args.mixed_precision is None:
             args.mixed_precision = accelerator.mixed_precision
+
+        # Model-specific init (sets _ltx_mode, _audio_video, dit_dtype, etc.)
+        self._net_trainer.handle_model_specific_args(args)
+
         is_main_process = accelerator.is_main_process
         dashboard_metrics_enabled = getattr(args, "gui", False) or os.getenv("MUSUBI_DASHBOARD_METRICS") == "1"
 
@@ -1194,8 +1206,21 @@ class LTX2SliderTrainer:
             torch.cuda.reset_peak_memory_stats()
 
         logger.info("Loading DiT model from %s", args.dit)
+        # Determine attention mode from args (mirror LTX2NetworkTrainer.load_transformer)
+        if getattr(args, "sdpa", False):
+            attn_mode = "torch"
+        elif getattr(args, "flash_attn", False):
+            attn_mode = "flash"
+        elif getattr(args, "flash3", False):
+            attn_mode = "flash3"
+        elif getattr(args, "sage_attn", False):
+            attn_mode = "sageattn"
+        elif getattr(args, "xformers", False):
+            attn_mode = "xformers"
+        else:
+            attn_mode = "torch"
         transformer = self._net_trainer.load_transformer(
-            accelerator, args, args.dit, "torch", False, loading_device, dit_weight_dtype
+            accelerator, args, args.dit, attn_mode, False, loading_device, dit_weight_dtype
         )
         transformer.eval()
         transformer.requires_grad_(False)

--- a/src/musubi_tuner/ltx2_train_slider.py
+++ b/src/musubi_tuner/ltx2_train_slider.py
@@ -1122,6 +1122,10 @@ class LTX2SliderTrainer:
             (None if getattr(args, "fp8_scaled", False) else torch.float8_e4m3fn) if getattr(args, "fp8_base", False) else dit_dtype
         )
 
+        # -- Pre-cache slider prompt embeddings (before DiT to avoid VRAM collision) --
+        if self.slider_config.mode == "text":
+            self._precache_slider_prompts(args, accelerator)
+
         # -- Sample prompt setup (for preview during training) ----------------
         vae_dtype = torch.float16 if args.vae_dtype is None else model_utils.str_to_dtype(args.vae_dtype)
         sample_parameters = None
@@ -1131,6 +1135,24 @@ class LTX2SliderTrainer:
             vae = self._net_trainer.load_vae(args, vae_dtype=vae_dtype, vae_path=args.vae)
             vae.requires_grad_(False)
             vae.eval()
+
+        # -- Pre-cache sample prompt embeddings (before DiT to avoid VRAM collision) --
+        if sample_parameters is not None:
+            needs_encoding = any(p.get("prompt_embeds") is None for p in sample_parameters)
+            if needs_encoding:
+                te_dtype = self._net_trainer._build_text_encoder(args, accelerator)
+                for sp in sample_parameters:
+                    if sp.get("prompt_embeds") is None:
+                        embed, mask = self._net_trainer._encode_prompt_text(accelerator, sp.get("prompt", ""), te_dtype)
+                        sp["prompt_embeds"] = embed
+                        sp["prompt_attention_mask"] = mask
+                        neg = sp.get("negative_prompt")
+                        if neg:
+                            ne, nm = self._net_trainer._encode_prompt_text(accelerator, neg, te_dtype)
+                            sp["negative_prompt_embeds"] = ne
+                            sp["negative_prompt_attention_mask"] = nm
+                self._net_trainer._cleanup_text_encoder(accelerator)
+                clean_memory_on_device(accelerator.device)
 
         # -- Load transformer -------------------------------------------------
         blocks_to_swap = int(getattr(args, "blocks_to_swap", 0) or 0)
@@ -1222,29 +1244,6 @@ class LTX2SliderTrainer:
             except TypeError:
                 network.enable_gradient_checkpointing()
 
-        # -- Pre-cache slider prompt embeddings --------------------------------
-        if self.slider_config.mode == "text":
-            self._precache_slider_prompts(args, accelerator)
-
-        # -- Pre-cache sample prompt embeddings --------------------------------
-        if sample_parameters is not None:
-            # Encode sample prompts if they don't already have embeddings
-            needs_encoding = any(p.get("prompt_embeds") is None for p in sample_parameters)
-            if needs_encoding:
-                te_dtype = self._net_trainer._build_text_encoder(args, accelerator)
-                for sp in sample_parameters:
-                    if sp.get("prompt_embeds") is None:
-                        embed, mask = self._net_trainer._encode_prompt_text(accelerator, sp.get("prompt", ""), te_dtype)
-                        sp["prompt_embeds"] = embed
-                        sp["prompt_attention_mask"] = mask
-                        neg = sp.get("negative_prompt")
-                        if neg:
-                            ne, nm = self._net_trainer._encode_prompt_text(accelerator, neg, te_dtype)
-                            sp["negative_prompt_embeds"] = ne
-                            sp["negative_prompt_attention_mask"] = nm
-                self._net_trainer._cleanup_text_encoder(accelerator)
-                clean_memory_on_device(accelerator.device)
-
         # -- Optimizer & scheduler ---------------------------------------------
         trainable_params, lr_descriptions = network.prepare_optimizer_params(unet_lr=args.learning_rate)
         optimizer_name, optimizer_args_str, optimizer, optimizer_train_fn, optimizer_eval_fn = NetworkTrainer().get_optimizer(
@@ -1272,6 +1271,77 @@ class LTX2SliderTrainer:
             transformer.eval()
 
         accelerator.unwrap_model(network).prepare_grad_etc(transformer)
+
+        # -- Resume from saved state (autoresume / --resume) --------------------
+        initial_global_step = 0
+        if getattr(args, "autoresume", False) and not getattr(args, "resume", None):
+            latest = self._net_trainer._find_latest_state_dir(args)
+            if latest:
+                logger.info(f"autoresume: found latest state directory: {latest}")
+                args.resume = latest
+                args._autoresume_selected = True
+            else:
+                logger.info("autoresume: no saved state found in output_dir, starting from scratch")
+                args._autoresume_selected = False
+        else:
+            args._autoresume_selected = getattr(args, "_autoresume_selected", False)
+
+        if getattr(args, "resume", None):
+            if not train_utils.is_complete_state_dir(args.resume):
+                if getattr(args, "_autoresume_selected", False):
+                    logger.warning("autoresume: selected state directory is missing or incomplete, starting from scratch: %s", args.resume)
+                    args.resume = None
+                else:
+                    raise FileNotFoundError(f"resume state directory is missing or incomplete: {args.resume}")
+
+        if getattr(args, "resume", None):
+            self._net_trainer._register_optimizer_resume_safe_globals(args)
+            logger.info(f"Resuming slider training from state: {args.resume}")
+            accelerator.load_state(args.resume)
+            resume_step = self._net_trainer._recover_global_step(args.resume)
+            if resume_step > 0:
+                initial_global_step = resume_step
+                logger.info(f"Recovered global_step={initial_global_step} from resume state")
+
+        # -- Fallback: resume from latest LoRA checkpoint if no state dir ------
+        # If autoresume is enabled but no state directory was found (e.g. crash
+        # without graceful save), scan output_dir for the highest-step LoRA
+        # checkpoint matching output_name and load its weights.
+        if (
+            initial_global_step == 0
+            and getattr(args, "autoresume", False)
+            and getattr(args, "network_weights", None) is None
+            and args.output_dir
+            and os.path.isdir(args.output_dir)
+        ):
+            import re as _re
+
+            best_step = 0
+            best_path = None
+            step_pattern = _re.compile(
+                _re.escape(args.output_name) + r"-step(\d+)\.safetensors$"
+            )
+            for entry in os.listdir(args.output_dir):
+                m = step_pattern.match(entry)
+                if m:
+                    step = int(m.group(1))
+                    full = os.path.join(args.output_dir, entry)
+                    if step > best_step and os.path.isfile(full):
+                        best_step = step
+                        best_path = full
+            if best_path is not None:
+                logger.info(
+                    "autoresume: no state dir found, but found LoRA checkpoint at step %d: %s",
+                    best_step,
+                    best_path,
+                )
+                info = accelerator.unwrap_model(network).load_weights(best_path)
+                logger.info("Loaded LoRA weights for resume: %s", info)
+                initial_global_step = best_step
+                logger.info(
+                    "Resuming from step %d (optimizer/scheduler re-initialized — weights only)",
+                    initial_global_step,
+                )
 
         # -- Reference dataloader (if reference mode) -------------------------
         ref_dataloader = None
@@ -1433,14 +1503,18 @@ class LTX2SliderTrainer:
             desc="steps",
         )
 
-        global_step = 0
+        global_step = initial_global_step
         loss_recorder = train_utils.LossRecorder()
 
         clean_memory_on_device(accelerator.device)
         optimizer_train_fn()
         optimizer.zero_grad(set_to_none=True)
 
-        logger.info("Starting slider training")
+        if initial_global_step > 0:
+            progress_bar.update(initial_global_step)
+            logger.info("Resuming slider training from step %d", initial_global_step)
+        else:
+            logger.info("Starting slider training")
         logger.info("  mode: %s", self.slider_config.mode)
         logger.info("  max_train_steps: %d", args.max_train_steps)
         logger.info("  learning_rate: %s", args.learning_rate)

--- a/src/musubi_tuner/ltx2_train_slider.py
+++ b/src/musubi_tuner/ltx2_train_slider.py
@@ -1373,10 +1373,12 @@ class LTX2SliderTrainer:
                 else:
                     raise FileNotFoundError(f"resume state directory is missing or incomplete: {args.resume}")
 
+        _resume_state_dir = None
         if getattr(args, "resume", None):
             self._net_trainer._register_optimizer_resume_safe_globals(args)
             logger.info(f"Resuming slider training from state: {args.resume}")
             accelerator.load_state(args.resume)
+            _resume_state_dir = args.resume
             resume_step = self._net_trainer._recover_global_step(args.resume)
             if resume_step > 0:
                 initial_global_step = resume_step
@@ -1556,6 +1558,31 @@ class LTX2SliderTrainer:
         # -- Save / remove helpers ---------------------------------------------
         save_dtype = dit_dtype
 
+        def _build_checkpoint_metadata() -> dict:
+            """Build the training-settings sidecar dict (shared by checkpoints and state dirs)."""
+            from datetime import datetime
+
+            _training = {
+                "step": global_step,
+                "epoch": 0,
+                "timestamp": datetime.now().isoformat(timespec="seconds"),
+            }
+            try:
+                _training["loss"] = float(loss)
+            except Exception:
+                pass
+            if loss_recorder.loss_list:
+                _training["loss_avg"] = loss_recorder.moving_average
+            try:
+                _training["lr"] = float(lr_scheduler.get_last_lr()[0])
+            except Exception:
+                pass
+            return {
+                "training": _training,
+                "command": _argv_to_command_list(),
+                "slider_config": asdict(self.slider_config),
+            }
+
         def save_model(ckpt_name: str, unwrapped_nw, steps, epoch_no, force_sync_upload=False):
             os.makedirs(args.output_dir, exist_ok=True)
             ckpt_file = os.path.join(args.output_dir, ckpt_name)
@@ -1575,29 +1602,7 @@ class LTX2SliderTrainer:
                 huggingface_utils.upload(args, ckpt_file, "/" + ckpt_name, force_sync_upload=force_sync_upload)
 
             if getattr(args, "save_checkpoint_metadata", False):
-                from datetime import datetime
-
-                _training = {
-                    "step": steps,
-                    "epoch": epoch_no,
-                    "timestamp": datetime.now().isoformat(timespec="seconds"),
-                }
-                try:
-                    _training["loss"] = float(loss)
-                except Exception:
-                    pass
-                if loss_recorder.loss_list:
-                    _training["loss_avg"] = loss_recorder.moving_average
-                try:
-                    _training["lr"] = float(lr_scheduler.get_last_lr()[0])
-                except Exception:
-                    pass
-                _md = {
-                    "training": _training,
-                    "command": _argv_to_command_list(),
-                    "slider_config": asdict(self.slider_config),
-                }
-                train_utils.save_checkpoint_metadata(ckpt_file, _md)
+                train_utils.save_checkpoint_metadata(ckpt_file, _build_checkpoint_metadata())
 
         def remove_model(old_ckpt_name):
             old_ckpt_file = os.path.join(args.output_dir, old_ckpt_name)
@@ -1659,6 +1664,7 @@ class LTX2SliderTrainer:
                         "interrupted": True,
                     },
                 )
+                train_utils.save_state_metadata(state_dir, _build_checkpoint_metadata())
                 if gui_metrics is not None:
                     gui_metrics.log_event("interrupt_state", global_step, path=str(state_dir))
             train_utils.clear_dashboard_stop_request()
@@ -1669,6 +1675,7 @@ class LTX2SliderTrainer:
         # -- Training loop -----------------------------------------------------
         progress_bar = tqdm(
             range(args.max_train_steps),
+            initial=initial_global_step,
             smoothing=0,
             disable=not accelerator.is_local_main_process,
             desc="steps",
@@ -1676,13 +1683,17 @@ class LTX2SliderTrainer:
 
         global_step = initial_global_step
         loss_recorder = train_utils.LossRecorder()
+        if initial_global_step > 0 and _resume_state_dir is not None:
+            _meta = train_utils.load_resume_metadata(_resume_state_dir)
+            if _meta and "loss_avg" in _meta:
+                loss_recorder.prefill(_meta["loss_avg"], _meta.get("loss_count", 0))
+                accelerator.print(f"  restored loss average: {_meta['loss_avg']:.4f} (from {_meta.get('loss_count', 0)} steps)")
 
         clean_memory_on_device(accelerator.device)
         optimizer_train_fn()
         optimizer.zero_grad(set_to_none=True)
 
         if initial_global_step > 0:
-            progress_bar.update(initial_global_step)
             logger.info("Resuming slider training from step %d", initial_global_step)
         else:
             logger.info("Starting slider training")
@@ -1830,6 +1841,18 @@ class LTX2SliderTrainer:
                             train_utils.save_and_remove_state_stepwise(
                                 args, accelerator, global_step, epoch=0, step_in_epoch=global_step
                             )
+                            _state_dir = os.path.join(
+                                args.output_dir,
+                                train_utils.STEP_STATE_NAME.format(args.output_name, global_step),
+                            )
+                            train_utils.update_resume_metadata(
+                                _state_dir,
+                                {
+                                    "loss_avg": loss_recorder.moving_average,
+                                    "loss_count": len(loss_recorder.loss_list),
+                                },
+                            )
+                            train_utils.save_state_metadata(_state_dir, _build_checkpoint_metadata())
 
                         remove_step_no = train_utils.get_remove_step_no(args, global_step)
                         if remove_step_no is not None:
@@ -1847,6 +1870,18 @@ class LTX2SliderTrainer:
 
         if is_main_process and (getattr(args, "save_state", False) or getattr(args, "save_state_on_train_end", False)):
             train_utils.save_state_on_train_end(args, accelerator, global_step=global_step, epoch=0, step_in_epoch=global_step)
+            _state_dir = os.path.join(
+                args.output_dir,
+                train_utils.LAST_STATE_NAME.format(args.output_name),
+            )
+            train_utils.update_resume_metadata(
+                _state_dir,
+                {
+                    "loss_avg": loss_recorder.moving_average,
+                    "loss_count": len(loss_recorder.loss_list),
+                },
+            )
+            train_utils.save_state_metadata(_state_dir, _build_checkpoint_metadata())
 
         if is_main_process:
             ckpt_name = train_utils.get_last_ckpt_name(args.output_name)

--- a/src/musubi_tuner/ltx_2/model/transformer/attention.py
+++ b/src/musubi_tuner/ltx_2/model/transformer/attention.py
@@ -14,6 +14,7 @@ logging.basicConfig(level=logging.INFO)
 _warned_flash2_mask_fallback = False
 _warned_flash2_query_mask_fallback = False
 _warned_flash3_mask_fallback = False
+_warned_sage_mask_fallback = False
 
 memory_efficient_attention = None
 flash_attn_interface = None
@@ -37,6 +38,11 @@ try:
         import flash_attn_interface
 except ImportError:
     flash_attn_interface = None
+sage_attn_func = None
+try:
+    from sageattention import sageattn as sage_attn_func
+except ImportError:
+    sage_attn_func = None
 
 try:
     import inspect as _inspect
@@ -300,11 +306,42 @@ class FlashAttention2(AttentionCallable):
         return out
 
 
+class SageAttention(AttentionCallable):
+    def __call__(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        heads: int,
+        mask: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if sage_attn_func is None:
+            raise RuntimeError("SageAttention was selected but `sageattention` is not installed.")
+
+        b, _, dim_head = q.shape
+        dim_head //= heads
+
+        if mask is not None:
+            global _warned_sage_mask_fallback
+            if not _warned_sage_mask_fallback:
+                logger.warning("SageAttention does not support attention masks; falling back to PyTorch SDPA.")
+                _warned_sage_mask_fallback = True
+            return PytorchAttention()(q, k, v, heads, mask)
+
+        # SageAttention expects [B, H, L, D] layout with tensor_layout="NHD" meaning [B, L, H, D]
+        q, k, v = (t.view(b, -1, heads, dim_head) for t in (q, k, v))
+
+        out = sage_attn_func(q, k, v, tensor_layout="NHD", is_causal=False)
+        out = out.reshape(b, -1, heads * dim_head)
+        return out
+
+
 class AttentionFunction(Enum):
     PYTORCH = "pytorch"
     XFORMERS = "xformers"
     FLASH_ATTENTION_2 = "flash_attention_2"
     FLASH_ATTENTION_3 = "flash_attention_3"
+    SAGE_ATTENTION = "sage_attention"
     DEFAULT = "default"
 
     def to_callable(self) -> AttentionCallable:
@@ -317,6 +354,8 @@ class AttentionFunction(Enum):
             return FlashAttention2()
         elif self is AttentionFunction.FLASH_ATTENTION_3:
             return FlashAttention3()
+        elif self is AttentionFunction.SAGE_ATTENTION:
+            return SageAttention()
         else:
             # Default behavior: XFormers if installed else - PyTorch (cuDNN-prioritized if opted in)
             if memory_efficient_attention is not None:

--- a/src/musubi_tuner/ltx_2/model/transformer/transformer.py
+++ b/src/musubi_tuner/ltx_2/model/transformer/transformer.py
@@ -19,6 +19,13 @@ from musubi_tuner.ltx_2.utils import rms_norm
 
 logger = logging.getLogger(__name__)
 
+# Resolved once at import so torch.compile can treat it as a compile-time
+# constant. When False (default; LTX2_ATTN_FP32_RETRY unset), the data-dependent
+# `torch.isfinite(out).all()` branch in _run_attn_with_optional_fp32_retry is
+# statically pruned by Dynamo instead of forcing a graph break in every block.
+# Reading it per-forward via os.getenv prevented constant folding.
+_ATTN_RETRY_FP32 = os.getenv("LTX2_ATTN_FP32_RETRY", "0") == "1"
+
 # Thread-local storage for tracking last loaded swapped block during backward
 import threading
 
@@ -38,6 +45,11 @@ def _reconstruct_transformer_args(values: list[Any], is_none: bool) -> Transform
     field_names = [f.name for f in fields(TransformerArgs)]
     kwargs = dict(zip(field_names, values))
     return TransformerArgs(**kwargs)
+    # NOTE: do not replace fields() with a precomputed constant here. Tested: it
+    # eliminates this graph break but causes torch.compile to trace more of the
+    # grad-sensitive block, which then recompiles on the slider's per-step
+    # grad_mode flips (~64 recompiles, ~3.9s/it vs ~2.0s/it). The break is
+    # benign / mildly beneficial for the compiled path.
 
 
 def _repack_block_checkpoint_outputs(
@@ -86,6 +98,21 @@ def _run_attn_with_optional_fp32_retry(
     same FlashAttention kernel in fp32 can still leave the graph in a bad state for
     backward when swap/fp8/checkpointing are active.
     """
+
+    # Fast path: no fp32 retry and no pytorch-backend override. This avoids both
+    # the data-dependent branch (torch.isfinite(...).all()) and the attribute
+    # mutation below, both of which force a torch.compile graph break in every
+    # block. attn_retry_fp32 defaults False (LTX2_ATTN_FP32_RETRY unset), so this
+    # is the normal training path. Behavior is identical to the general path when
+    # both flags are off.
+    if not attn_retry_fp32 and not force_pytorch:
+        if force_fp32:
+            x = x_in.to(torch.float32)
+            ctx = context.to(torch.float32) if isinstance(context, torch.Tensor) else None
+            pe_local = pe.to(torch.float32) if isinstance(pe, torch.Tensor) else None
+            k_pe_local = k_pe.to(torch.float32) if isinstance(k_pe, torch.Tensor) else None
+            return attn_module(x, context=ctx, mask=mask, pe=pe_local, k_pe=k_pe_local).to(dtype=x_in.dtype)
+        return attn_module(x_in, context=context, mask=mask, pe=pe, k_pe=k_pe)
 
     original_fn = getattr(attn_module, "attention_function", None)
 
@@ -511,7 +538,7 @@ class BasicAVTransformerBlock(torch.nn.Module):
     ) -> tuple[TransformerArgs | None, TransformerArgs | None]:
         sublayer_diag = os.getenv("LTX2_NAN_SUBLAYER_DIAG", "0") == "1"
         v2a_diag = os.getenv("LTX2_V2A_DIAG", "0") == "1"
-        attn_retry_fp32 = os.getenv("LTX2_ATTN_FP32_RETRY", "0") == "1"
+        attn_retry_fp32 = _ATTN_RETRY_FP32
         # Clamp FFN outputs to prevent bf16 overflow (max ~65504).
         # Set LTX2_FFN_CLAMP=60000 to enable. Default: disabled (0).
         ffn_clamp = float(os.getenv("LTX2_FFN_CLAMP", "0"))

--- a/src/musubi_tuner/ltx_2/text_encoders/gemma/encoders/base_encoder.py
+++ b/src/musubi_tuner/ltx_2/text_encoders/gemma/encoders/base_encoder.py
@@ -644,6 +644,23 @@ def module_ops_from_gemma_root(
                             tensor = f.get_tensor(key)
 
                             with torch.no_grad():
+                                # Dequantize NVFP4 packed weights (uint8 with two-level scales)
+                                if tensor.dtype == torch.uint8 and key.endswith(".weight"):
+                                    prefix = key[:-len(".weight")]
+                                    wscale_k = prefix + ".weight_scale"
+                                    wscale2_k = prefix + ".weight_scale_2"
+                                    if wscale_k in keys and wscale2_k in keys:
+                                        from musubi_tuner.modules.nvfp4_utils import dequantize_nvfp4_weight
+                                        block_scale = f.get_tensor(wscale_k)
+                                        tensor_scale = f.get_tensor(wscale2_k)
+                                        tensor = dequantize_nvfp4_weight(tensor, block_scale, tensor_scale, dtype=torch_dtype)
+                                # Dequantize ComfyUI FP8 weights with per-tensor scale
+                                elif tensor.dtype.itemsize == 1 and tensor.dtype != torch.uint8 and key.endswith(".weight"):
+                                    wscale_k = key.replace(".weight", ".weight_scale")
+                                    if wscale_k in keys:
+                                        scale = f.get_tensor(wscale_k)
+                                        tensor = tensor.to(torch_dtype) * scale.to(torch_dtype)
+
                                 if param.shape != tensor.shape:
                                     # Handle specialized shape mismatches if necessary, or error
                                     logger.warning(f"Shape mismatch for {new_key}: model {param.shape} vs ckpt {tensor.shape}")

--- a/src/musubi_tuner/modules/nvfp4_utils.py
+++ b/src/musubi_tuner/modules/nvfp4_utils.py
@@ -1,0 +1,295 @@
+"""NVIDIA FP4 (E2M1) checkpoint loading utilities for pre-quantized LTX-2 models.
+
+Handles the Lightricks nvfp4 checkpoint format where transformer block weights
+(typically blocks 10-47) are stored as packed uint8 with two-level scaling:
+  - ``weight``: uint8 packed (two FP4 E2M1 nibbles per byte), shape ``[out, in/2]``
+  - ``weight_scale``: float8_e4m3fn per-block scales
+  - ``weight_scale_2``: float32 per-tensor scalar scale
+
+Early blocks (0-9), VAE, vocoder, connectors, biases, and norms are stored in bf16
+and passed through unchanged.
+
+The on-the-fly forward patch keeps packed weights in GPU memory (~10-11 GB for the
+transformer) and dequantizes to bf16 only during each ``F.linear`` call, mirroring
+the approach used by ``nf4_optimization_utils.py``.
+"""
+
+import json
+import os
+from typing import Callable, List, Optional, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import logging
+
+from tqdm import tqdm
+
+from musubi_tuner.utils.safetensors_utils import MemoryEfficientSafeOpen, TensorWeightAdapter, WeightTransformHooks
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# FP4 E2M1 lookup table
+# ---------------------------------------------------------------------------
+# Nibble values 0x0-0x7 are positive, 0x8-0xF are negative mirrors.
+FP4_E2M1_LUT = torch.tensor(
+    [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+     -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
+    dtype=torch.bfloat16,
+)
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+def detect_nvfp4_checkpoint(model_path: str) -> bool:
+    """Check whether a safetensors file is in Lightricks nvfp4 format.
+
+    Detection is based on the ``_quantization_metadata`` key in the file
+    metadata containing ``"nvfp4"`` format entries, or the presence of
+    ``weight_scale_2`` keys alongside ``weight_scale`` keys.
+    """
+    try:
+        from safetensors import safe_open
+        check_path = model_path if isinstance(model_path, str) else model_path[0]
+        with safe_open(check_path, framework="pt") as f:
+            meta = f.metadata()
+            if meta is not None:
+                qm = meta.get("_quantization_metadata", "")
+                if '"nvfp4"' in qm:
+                    return True
+            # Fallback: check for weight_scale_2 keys
+            keys = f.keys()
+            has_ws2 = any(k.endswith(".weight_scale_2") for k in keys)
+            has_ws = any(k.endswith(".weight_scale") for k in keys)
+            has_uint8 = False
+            if has_ws2 and has_ws:
+                # Confirm at least one uint8 weight
+                for k in keys:
+                    if k.endswith(".weight"):
+                        t = f.get_tensor(k)
+                        if t.dtype == torch.uint8:
+                            has_uint8 = True
+                            break
+            return has_ws2 and has_ws and has_uint8
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Dequantize (for on-the-fly forward or one-shot conversion)
+# ---------------------------------------------------------------------------
+
+def dequantize_nvfp4_weight(
+    w_uint8: torch.Tensor,
+    block_scale: torch.Tensor,
+    tensor_scale: torch.Tensor,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Dequantize an NVFP4-packed weight tensor.
+
+    Args:
+        w_uint8: Packed weight ``[out_features, in_features // 2]`` as uint8.
+        block_scale: Per-block scales (float8_e4m3fn or similar), flattened or shaped.
+        tensor_scale: Per-tensor scalar scale (float32).
+        dtype: Output dtype.
+
+    Returns:
+        ``[out_features, in_features]`` tensor in *dtype*.
+    """
+    lut = FP4_E2M1_LUT.to(w_uint8.device)
+
+    # Unpack two 4-bit values from each byte
+    lo = (w_uint8 & 0x0F).to(torch.int64)
+    hi = (w_uint8 >> 4).to(torch.int64)
+    # Interleave: low nibble first, then high nibble (NVFP4 byte order)
+    unpacked = torch.stack([lo, hi], dim=-1).reshape(-1)
+
+    # Map 4-bit indices to FP4 E2M1 float values
+    values = lut[unpacked]
+
+    # Apply block scales: each scale covers a fixed group of consecutive values
+    # Cast scales to bfloat16 first — PyTorch cannot promote float8 * bfloat16 directly
+    total_values = values.shape[0]
+    total_scales = block_scale.numel()
+    block_size = total_values // total_scales
+    bs_flat = block_scale.to(torch.bfloat16).to(w_uint8.device).reshape(-1).repeat_interleave(block_size)
+
+    result = values * bs_flat * tensor_scale.to(torch.bfloat16).to(w_uint8.device)
+
+    # Reshape to real weight dimensions (2x columns since 2 values per packed byte)
+    real_shape = (w_uint8.shape[0], w_uint8.shape[1] * 2)
+    return result.reshape(real_shape).to(dtype)
+
+
+# ---------------------------------------------------------------------------
+# Monkey-patched forward
+# ---------------------------------------------------------------------------
+
+def nvfp4_linear_forward_patch(self: nn.Linear, x: torch.Tensor) -> torch.Tensor:
+    """Drop-in replacement forward for NVFP4-quantized Linear layers.
+
+    Dequantizes packed uint8 weights on-the-fly using the stored block and
+    tensor scales, then runs a standard ``F.linear``.
+    """
+    w = dequantize_nvfp4_weight(
+        self.weight,               # packed uint8 [out, in//2]
+        self.nvfp4_block_scale,    # float8_e4m3fn block scales
+        self.nvfp4_tensor_scale,   # float32 per-tensor scale
+        dtype=torch.bfloat16,
+    )
+    # Cast to input dtype for the matmul (e.g. if input is fp32 or fp16)
+    if w.dtype != x.dtype:
+        w = w.to(x.dtype)
+    return F.linear(x, w, self.bias)
+
+
+# ---------------------------------------------------------------------------
+# Monkey-patch application (mirrors apply_nf4_monkey_patch)
+# ---------------------------------------------------------------------------
+
+def apply_nvfp4_monkey_patch(
+    model: nn.Module,
+    state_dict: dict,
+) -> nn.Module:
+    """Register NVFP4 buffers and replace forward on quantized Linears.
+
+    Identifies quantized layers by looking for ``weight_scale`` and
+    ``weight_scale_2`` keys in the state dict alongside uint8 ``.weight``
+    tensors.  Non-quantized layers (bf16 weights) are left untouched.
+    """
+    # Collect quantized module paths from state dict.
+    # Keys have been renamed by load_nvfp4_state_dict:
+    #   .weight_scale   -> .nvfp4_block_scale
+    #   .weight_scale_2 -> .nvfp4_tensor_scale
+    nvfp4_modules: dict = {}  # module_path -> (packed_shape, real_out, real_in)
+    for key in state_dict:
+        if key.endswith(".nvfp4_tensor_scale"):
+            module_path = key.rsplit(".nvfp4_tensor_scale", 1)[0]
+            weight_key = module_path + ".weight"
+            bs_key = module_path + ".nvfp4_block_scale"
+            if weight_key in state_dict and bs_key in state_dict:
+                wt = state_dict[weight_key]
+                if wt.dtype == torch.uint8:
+                    out_f = wt.shape[0]
+                    in_f = wt.shape[1] * 2  # real in_features (2 values per packed byte)
+                    nvfp4_modules[module_path] = (wt.shape, out_f, in_f)
+
+    patched_count = 0
+    for name, module in model.named_modules():
+        if name not in nvfp4_modules:
+            continue
+        if not isinstance(module, nn.Linear):
+            continue
+
+        packed_shape, out_f, in_f = nvfp4_modules[name]
+        bs_key = name + ".nvfp4_block_scale"
+        ts_key = name + ".nvfp4_tensor_scale"
+
+        # Replace the weight parameter with a buffer of packed shape
+        # so load_state_dict(assign=True) doesn't complain about shape mismatch.
+        del module.weight
+        module.register_buffer("weight", torch.zeros(packed_shape, dtype=torch.uint8))
+
+        # Register scale buffers
+        bs_tensor = state_dict[bs_key]
+        ts_tensor = state_dict[ts_key]
+        module.register_buffer("nvfp4_block_scale", torch.zeros_like(bs_tensor))
+        module.register_buffer("nvfp4_tensor_scale", torch.zeros_like(ts_tensor))
+
+        # Store metadata
+        module.nvfp4_out_features = out_f
+        module.nvfp4_in_features = in_f
+        module._nvfp4_quantized = True
+
+        # Replace forward
+        def new_forward(self, x):
+            return nvfp4_linear_forward_patch(self, x)
+        module.forward = new_forward.__get__(module, type(module))
+        patched_count += 1
+
+    logger.info(f"Number of NVFP4 monkey-patched Linear layers: {patched_count}")
+    return model
+
+
+# ---------------------------------------------------------------------------
+# State dict loading for nvfp4 checkpoints
+# ---------------------------------------------------------------------------
+
+def load_nvfp4_state_dict(
+    model_files: Union[str, List[str]],
+    state_dict_key_filter: Optional[Callable[[str], bool]] = None,
+    move_to_device: bool = False,
+    target_device: Optional[Union[str, torch.device]] = None,
+) -> dict:
+    """Load an nvfp4 checkpoint into a state dict, preserving packed format.
+
+    Quantized layers keep their uint8 packed weights, weight_scale (fp8), and
+    weight_scale_2 (fp32) as separate state dict entries.  Non-quantized layers
+    (bf16) are loaded as-is.
+
+    The ``weight_scale`` / ``weight_scale_2`` keys are renamed to
+    ``nvfp4_block_scale`` / ``nvfp4_tensor_scale`` in the output so they
+    match the buffer names registered by ``apply_nvfp4_monkey_patch``.
+    """
+    if isinstance(model_files, str):
+        model_files = [model_files]
+
+    state_dict = {}
+    for model_file in model_files:
+        with MemoryEfficientSafeOpen(model_file) as f:
+            all_keys = list(f.keys())
+
+            # Identify quantized layers
+            ws2_keys = set(k for k in all_keys if k.endswith(".weight_scale_2"))
+            ws_keys = set(k for k in all_keys if k.endswith(".weight_scale"))
+            skip_suffixes = (".weight_scale", ".weight_scale_2", ".pre_quant_scale", ".input_scale", ".comfy_quant")
+
+            for key in tqdm(all_keys, desc=f"Loading {os.path.basename(model_file)}", unit="key"):
+                if state_dict_key_filter is not None and not state_dict_key_filter(key):
+                    continue
+
+                # Skip auxiliary scale keys — they are loaded alongside their .weight
+                if key.endswith(skip_suffixes):
+                    continue
+
+                value = f.get_tensor(key)
+
+                # For uint8 .weight tensors with nvfp4 scales, also load the scales
+                if value.dtype == torch.uint8 and key.endswith(".weight"):
+                    prefix = key[:-len(".weight")]
+                    ws_key = prefix + ".weight_scale"
+                    ws2_key = prefix + ".weight_scale_2"
+                    if ws_key in ws_keys and ws2_key in ws2_keys:
+                        # Load scales and store with buffer-compatible names
+                        block_scale = f.get_tensor(ws_key)
+                        tensor_scale = f.get_tensor(ws2_key)
+
+                        if move_to_device and target_device is not None:
+                            value = value.to(target_device)
+                            block_scale = block_scale.to(target_device)
+                            tensor_scale = tensor_scale.to(target_device)
+
+                        state_dict[key] = value
+                        state_dict[prefix + ".nvfp4_block_scale"] = block_scale
+                        state_dict[prefix + ".nvfp4_tensor_scale"] = tensor_scale
+                        continue
+
+                # Non-quantized tensor — load normally
+                if move_to_device and target_device is not None:
+                    value = value.to(target_device)
+                state_dict[key] = value
+
+    return state_dict
+
+
+# ---------------------------------------------------------------------------
+# Detection helper
+# ---------------------------------------------------------------------------
+
+def is_nvfp4_module(module: nn.Module) -> bool:
+    """Check whether *module* has been NVFP4-quantized."""
+    return getattr(module, "_nvfp4_quantized", False)

--- a/src/musubi_tuner/training/training_loop.py
+++ b/src/musubi_tuner/training/training_loop.py
@@ -645,6 +645,13 @@ def train(self, args):
         transformer = accelerator.prepare(transformer)
         _log_vram("AFTER accelerator.prepare(transformer) without block swap", logger)
 
+    # The frozen base transformer was added to accelerator._models by prepare(),
+    # which means save_state() would serialize it (~13 GB) even though its weights
+    # never change during LoRA training.  Remove it so only the LoRA network
+    # (prepared below) is included in state checkpoints.
+    _unwrapped_transformer = accelerator.unwrap_model(transformer)
+    accelerator._models = [m for m in accelerator._models if accelerator.unwrap_model(m) is not _unwrapped_transformer]
+
     if args.compile:
         transformer = self.compile_transformer(args, transformer)
         transformer.__dict__["_orig_mod"] = transformer  # for annoying accelerator checks

--- a/src/musubi_tuner/utils/train_utils.py
+++ b/src/musubi_tuner/utils/train_utils.py
@@ -226,6 +226,16 @@ def save_checkpoint_metadata(ckpt_file: str, metadata: dict) -> None:
         json.dump(clean, f, indent=2)
 
 
+def save_state_metadata(state_dir: str, metadata: dict) -> None:
+    """Write a JSON sidecar with training settings inside a state directory."""
+    path = os.path.join(state_dir, "slider_metadata.json")
+    clean = {k: v for k, v in metadata.items() if v is not None}
+    tmp = path + ".tmp"
+    with open(tmp, "w") as f:
+        json.dump(clean, f, indent=2)
+    os.replace(tmp, path)
+
+
 def remove_checkpoint_metadata(ckpt_file: str) -> None:
     """Remove JSON sidecar if it exists."""
     json_path = os.path.splitext(ckpt_file)[0] + ".json"


### PR DESCRIPTION
This all works pretty well.  The only thing not updated in the PR is the dist files.

I'm marking it as WIP since I don't have time at the moment to write out a full description of the whole thing, although the commits are thoroughly documented.

I mostly bring the slider lora trainer more in line with the features of the regular trainer.  It now has a console to see what's going on, and it creates all the logs necessary for the GUI as well as TensorBoard.  It can properly resume.
There was a huge issue where it loaded the LTX model first, then loaded Gemma to cache the prompt, forcing both to be loaded at the same time, I just flipped the order, now it caches the prompt with Gemma, unloads, then loads LTX.  Massively helps memory.

I did add some NVFP4 support for the main model, but I'm still testing that out to see if it's worth training against.  As soon as I know what works really well on FP16, I'll try it out on the NVFP4 version.  I hope it works well, because the NVFP4 when training only took 14gb VRAM.

Oh, I also added support for SageAttention on the slider.

So for now this is just to let you know this exist till I review it and make sure I didn't include anything unnecessary.