### PR TITLE
Implement resume functionality in training process

### DIFF
--- a/src/musubi_tuner/training/resume_utils.py
+++ b/src/musubi_tuner/training/resume_utils.py
@@ -1,0 +1,38 @@
+"""Helpers for recovering Musubi training position from Accelerate states."""
+
+import logging
+import os
+import pickle
+
+import torch
+
+from musubi_tuner.utils import train_utils
+
+logger = logging.getLogger(__name__)
+
+
+def recover_global_step(state_dir: str) -> int:
+    """Recover Musubi's optimization step from new or legacy state directories."""
+    metadata = train_utils.load_resume_metadata(state_dir)
+    if metadata is not None:
+        try:
+            global_step = int(metadata.get("global_step", 0))
+            if global_step > 0:
+                logger.info("Recovered global_step=%d from %s", global_step, train_utils.RESUME_METADATA_NAME)
+                return global_step
+        except (TypeError, ValueError) as e:
+            logger.warning("Invalid global_step in %s: %s", train_utils.RESUME_METADATA_NAME, e)
+
+    scheduler_path = os.path.join(state_dir, "scheduler.bin")
+    try:
+        scheduler_state = torch.load(scheduler_path, map_location="cpu", weights_only=True)
+        global_step = int(scheduler_state["last_epoch"])
+        logger.info("Recovered global_step=%d from %s", global_step, scheduler_path)
+        return global_step
+    except (OSError, RuntimeError, KeyError, TypeError, ValueError, EOFError, pickle.UnpicklingError) as e:
+        logger.warning(
+            "Could not recover global step from %s: %s; training bookkeeping will start from step 0",
+            scheduler_path,
+            e,
+        )
+        return 0

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -57,6 +57,7 @@ from musubi_tuner.training.accelerator_setup import (
     collator_class,
     prepare_accelerator,
 )
+from musubi_tuner.training.resume_utils import recover_global_step
 from musubi_tuner.training.sampling_prompts import should_sample_images
 from musubi_tuner.training.validation import ValidationEventDeduplicator, should_validate, validate_validation_args
 from musubi_tuner.training.timesteps import (
@@ -451,14 +452,20 @@ class NetworkTrainer:
             **lr_scheduler_kwargs,
         )
 
-    def resume_from_local_or_hf_if_specified(self, accelerator: Accelerator, args: argparse.Namespace) -> bool:
+    @staticmethod
+    def recover_global_step(state_dir: str) -> int:
+        return recover_global_step(state_dir)
+
+    def resume_from_local_or_hf_if_specified(self, accelerator: Accelerator, args: argparse.Namespace) -> int:
         if not args.resume:
-            return False
+            self._resume_state_dir = None
+            return 0
 
         if not args.resume_from_huggingface:
             logger.info(f"resume training from local state: {args.resume}")
             accelerator.load_state(args.resume)
-            return True
+            self._resume_state_dir = args.resume
+            return self.recover_global_step(args.resume)
 
         logger.info(f"resume training from huggingface state: {args.resume}")
         repo_id = args.resume.split("/")[0] + "/" + args.resume.split("/")[1]
@@ -502,8 +509,9 @@ class NetworkTrainer:
             )
         dirname = os.path.dirname(results[0])
         accelerator.load_state(dirname)
+        self._resume_state_dir = dirname
 
-        return True
+        return self.recover_global_step(dirname)
 
     def get_bucketed_timestep(self) -> float:
         if self.num_timestep_buckets is None or self.num_timestep_buckets <= 1:
@@ -1399,7 +1407,7 @@ class NetworkTrainer:
             dit_dtype,
             dit_weight_dtype,
         )
-        self._register_hooks_and_resume(args, accelerator, network)
+        initial_global_step = self._register_hooks_and_resume(args, accelerator, network)
         self._run_training_loop(
             args,
             accelerator,
@@ -1422,6 +1430,7 @@ class NetworkTrainer:
             sample_parameters,
             dit_dtype,
             network_dtype,
+            initial_global_step=initial_global_step,
         )
 
     def _validate_args_and_init(self, args) -> bool:
@@ -1809,8 +1818,7 @@ class NetworkTrainer:
         accelerator.register_save_state_pre_hook(save_model_hook)
         accelerator.register_load_state_pre_hook(load_model_hook)
 
-        # resume from local or huggingface. accelerator.step is set
-        self.resume_from_local_or_hf_if_specified(accelerator, args)  # accelerator.load_state(args.resume)
+        return self.resume_from_local_or_hf_if_specified(accelerator, args)
 
     def _run_training_loop(
         self,
@@ -1835,6 +1843,7 @@ class NetworkTrainer:
         sample_parameters,
         dit_dtype,
         network_dtype,
+        initial_global_step=0,
     ):
         is_main_process = accelerator.is_main_process
 
@@ -1964,11 +1973,31 @@ class NetworkTrainer:
                 init_kwargs=init_kwargs,
             )
 
-        # TODO skip until initial step
-        progress_bar = tqdm(range(args.max_train_steps), smoothing=0, disable=not accelerator.is_local_main_process, desc="steps")
+        resume_metadata = None
+        resume_state_dir = getattr(self, "_resume_state_dir", None)
+        if initial_global_step > 0 and resume_state_dir is not None:
+            resume_metadata = train_utils.load_resume_metadata(resume_state_dir)
 
-        epoch_to_start = 0
-        global_step = 0
+        epoch_to_start, steps_to_skip_in_epoch = train_utils.get_resume_position(
+            initial_global_step,
+            num_update_steps_per_epoch,
+            resume_metadata,
+        )
+
+        global_step = initial_global_step
+        progress_bar = tqdm(
+            total=args.max_train_steps,
+            initial=initial_global_step,
+            smoothing=0,
+            disable=not accelerator.is_local_main_process,
+            desc="steps",
+        )
+        if initial_global_step > 0:
+            message = f"  resuming from step {initial_global_step}, epoch {epoch_to_start + 1}/{num_train_epochs}"
+            if steps_to_skip_in_epoch > 0:
+                message += f", skipping {steps_to_skip_in_epoch} batches in epoch"
+            accelerator.print(message)
+
         noise_scheduler = FlowMatchDiscreteScheduler(shift=args.discrete_flow_shift, reverse=True, solver="euler")
 
         loss_recorder = train_utils.LossRecorder()
@@ -2062,7 +2091,7 @@ class NetworkTrainer:
 
         # Validation intentionally precedes sampling when both run at startup.
         should_validate_at_start = should_validate(args, global_step, epoch=0, at_start=True)
-        should_sample_at_start = should_sample_images(args, global_step, epoch=0)
+        should_sample_at_start = global_step == 0 and should_sample_images(args, global_step, epoch=0)
         if should_validate_at_start or should_sample_at_start:
             optimizer_eval_fn()
             if should_validate_at_start:
@@ -2072,7 +2101,7 @@ class NetworkTrainer:
             optimizer_train_fn()
         if len(accelerator.trackers) > 0:
             # log empty object to commit the sample images to wandb
-            accelerator.log({}, step=0)
+            accelerator.log({}, step=global_step)
 
         # training loop
 
@@ -2087,7 +2116,19 @@ class NetworkTrainer:
 
         optimizer_train_fn()  # Set training mode
 
+        last_epoch = epoch_to_start
+        last_step_in_epoch = 0
+        if resume_metadata is not None:
+            try:
+                if int(resume_metadata.get("global_step", 0)) > 0:
+                    last_epoch = int(resume_metadata.get("epoch", last_epoch))
+                    last_step_in_epoch = int(resume_metadata.get("step_in_epoch", 0))
+            except (TypeError, ValueError):
+                last_epoch = epoch_to_start
+                last_step_in_epoch = 0
         for epoch in range(epoch_to_start, num_train_epochs):
+            if global_step >= args.max_train_steps:
+                break
             accelerator.print(f"\nepoch {epoch + 1}/{num_train_epochs}")
             current_epoch.value = epoch + 1
 
@@ -2096,6 +2137,10 @@ class NetworkTrainer:
             accelerator.unwrap_model(network).on_epoch_start(transformer)
 
             for step, batch in enumerate(train_dataloader):
+                if steps_to_skip_in_epoch > 0:
+                    steps_to_skip_in_epoch -= 1
+                    continue
+
                 # torch.compiler.cudagraph_mark_step_begin() # for cudagraphs
 
                 latents = self.get_primary_latents(batch)
@@ -2183,7 +2228,13 @@ class NetworkTrainer:
                                 save_model(ckpt_name, accelerator.unwrap_model(network), global_step, epoch)
 
                                 if args.save_state:
-                                    train_utils.save_and_remove_state_stepwise(args, accelerator, global_step)
+                                    train_utils.save_and_remove_state_stepwise(
+                                        args,
+                                        accelerator,
+                                        global_step,
+                                        epoch=epoch + 1,
+                                        step_in_epoch=step + 1,
+                                    )
 
                                 remove_step_no = train_utils.get_remove_step_no(args, global_step)
                                 if remove_step_no is not None:
@@ -2209,8 +2260,14 @@ class NetworkTrainer:
                     logs.update(self.extra_step_logs(args, logs))
                     accelerator.log(logs, step=global_step)
 
+                last_epoch = epoch + 1
+                last_step_in_epoch = step + 1
+
                 if global_step >= args.max_train_steps:
                     break
+
+            if last_epoch == epoch + 1 and last_step_in_epoch >= len(train_dataloader):
+                last_step_in_epoch = 0
 
             if len(accelerator.trackers) > 0:
                 logs = {"loss/epoch": loss_recorder.moving_average}
@@ -2232,7 +2289,13 @@ class NetworkTrainer:
                         remove_model(remove_ckpt_name)
 
                     if args.save_state:
-                        train_utils.save_and_remove_state_on_epoch_end(args, accelerator, epoch + 1)
+                        train_utils.save_and_remove_state_on_epoch_end(
+                            args,
+                            accelerator,
+                            epoch + 1,
+                            global_step=global_step,
+                            step_in_epoch=0,
+                        )
 
             _do_validation(epoch + 1, global_step)
             _do_sample(epoch + 1, global_step)
@@ -2250,7 +2313,13 @@ class NetworkTrainer:
         optimizer_eval_fn()
 
         if is_main_process and (args.save_state or args.save_state_on_train_end):
-            train_utils.save_state_on_train_end(args, accelerator)
+            train_utils.save_state_on_train_end(
+                args,
+                accelerator,
+                global_step=global_step,
+                epoch=last_epoch,
+                step_in_epoch=last_step_in_epoch,
+            )
 
         if is_main_process:
             ckpt_name = train_utils.get_last_ckpt_name(args.output_name)

--- a/src/musubi_tuner/utils/train_utils.py
+++ b/src/musubi_tuner/utils/train_utils.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import argparse
+import json
 import logging
 import os
 import shutil
@@ -15,6 +18,7 @@ logging.basicConfig(level=logging.INFO)
 
 
 # checkpointファイル名
+RESUME_METADATA_NAME = "resume_metadata.json"
 EPOCH_STATE_NAME = "{}-{:06d}-state"
 EPOCH_FILE_NAME = "{}-{:06d}"
 EPOCH_DIFFUSERS_DIR_NAME = "{}-{:06d}"
@@ -22,6 +26,58 @@ LAST_STATE_NAME = "{}-state"
 STEP_STATE_NAME = "{}-step{:08d}-state"
 STEP_FILE_NAME = "{}-step{:08d}"
 STEP_DIFFUSERS_DIR_NAME = "{}-step{:08d}"
+
+
+def save_resume_metadata(state_dir: str, global_step: int, step_in_epoch: int, epoch: int) -> None:
+    """Atomically save Musubi's training position beside an Accelerate state."""
+    metadata = {
+        "global_step": int(global_step),
+        "step_in_epoch": int(step_in_epoch),
+        "epoch": int(epoch),
+    }
+    path = os.path.join(state_dir, RESUME_METADATA_NAME)
+    tmp_path = path + ".tmp"
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        json.dump(metadata, f)
+    os.replace(tmp_path, path)
+
+
+def load_resume_metadata(state_dir: str) -> dict | None:
+    """Load Musubi training-position metadata, if this state has it."""
+    path = os.path.join(state_dir, RESUME_METADATA_NAME)
+    if not os.path.exists(path):
+        return None
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, UnicodeError, json.JSONDecodeError, TypeError) as e:
+        logger.warning("Could not read resume metadata from %s: %s", path, e)
+        return None
+
+
+def get_resume_position(
+    initial_global_step: int,
+    num_update_steps_per_epoch: int,
+    metadata: dict | None,
+) -> tuple[int, int]:
+    """Return the zero-based epoch and number of already-consumed batches to skip."""
+    if initial_global_step <= 0:
+        return 0, 0
+
+    try:
+        metadata_global_step = int(metadata.get("global_step", 0)) if metadata is not None else 0
+    except (TypeError, ValueError):
+        metadata_global_step = 0
+
+    if metadata_global_step > 0:
+        saved_epoch = int(metadata.get("epoch", 1))
+        step_in_epoch = int(metadata.get("step_in_epoch", 0))
+        if step_in_epoch > 0:
+            return max(saved_epoch - 1, 0), step_in_epoch
+        return max(saved_epoch, 0), 0
+
+    return initial_global_step // max(num_update_steps_per_epoch, 1), 0
 
 
 def get_sanitized_config_or_none(args: argparse.Namespace):
@@ -116,7 +172,13 @@ def get_remove_step_no(args: argparse.Namespace, step_no: int):
     return remove_step_no
 
 
-def save_and_remove_state_on_epoch_end(args: argparse.Namespace, accelerator: accelerate.Accelerator, epoch_no: int):
+def save_and_remove_state_on_epoch_end(
+    args: argparse.Namespace,
+    accelerator: accelerate.Accelerator,
+    epoch_no: int,
+    global_step: int = 0,
+    step_in_epoch: int = 0,
+):
     model_name = args.output_name
 
     logger.info("")
@@ -125,6 +187,7 @@ def save_and_remove_state_on_epoch_end(args: argparse.Namespace, accelerator: ac
 
     state_dir = os.path.join(args.output_dir, EPOCH_STATE_NAME.format(model_name, epoch_no))
     accelerator.save_state(state_dir)
+    save_resume_metadata(state_dir, global_step, step_in_epoch, epoch_no)
     if args.save_state_to_huggingface:
         logger.info("uploading state to huggingface.")
         huggingface_utils.upload(args, state_dir, "/" + EPOCH_STATE_NAME.format(model_name, epoch_no))
@@ -138,7 +201,13 @@ def save_and_remove_state_on_epoch_end(args: argparse.Namespace, accelerator: ac
             shutil.rmtree(state_dir_old)
 
 
-def save_and_remove_state_stepwise(args: argparse.Namespace, accelerator: accelerate.Accelerator, step_no: int):
+def save_and_remove_state_stepwise(
+    args: argparse.Namespace,
+    accelerator: accelerate.Accelerator,
+    step_no: int,
+    epoch: int = 0,
+    step_in_epoch: int = 0,
+):
     model_name = args.output_name
 
     logger.info("")
@@ -147,6 +216,7 @@ def save_and_remove_state_stepwise(args: argparse.Namespace, accelerator: accele
 
     state_dir = os.path.join(args.output_dir, STEP_STATE_NAME.format(model_name, step_no))
     accelerator.save_state(state_dir)
+    save_resume_metadata(state_dir, step_no, step_in_epoch, epoch)
     if args.save_state_to_huggingface:
         logger.info("uploading state to huggingface.")
         huggingface_utils.upload(args, state_dir, "/" + STEP_STATE_NAME.format(model_name, step_no))
@@ -164,7 +234,13 @@ def save_and_remove_state_stepwise(args: argparse.Namespace, accelerator: accele
                 shutil.rmtree(state_dir_old)
 
 
-def save_state_on_train_end(args: argparse.Namespace, accelerator: accelerate.Accelerator):
+def save_state_on_train_end(
+    args: argparse.Namespace,
+    accelerator: accelerate.Accelerator,
+    global_step: int = 0,
+    epoch: int = 0,
+    step_in_epoch: int = 0,
+):
     model_name = args.output_name
 
     logger.info("")
@@ -173,6 +249,7 @@ def save_state_on_train_end(args: argparse.Namespace, accelerator: accelerate.Ac
 
     state_dir = os.path.join(args.output_dir, LAST_STATE_NAME.format(model_name))
     accelerator.save_state(state_dir)
+    save_resume_metadata(state_dir, global_step, step_in_epoch, epoch)
 
     if args.save_state_to_huggingface:
         logger.info("uploading last state to huggingface.")

--- a/tests/test_resume_state.py
+++ b/tests/test_resume_state.py
@@ -1,0 +1,93 @@
+import json
+from types import SimpleNamespace
+
+import torch
+
+from musubi_tuner.training.resume_utils import recover_global_step
+from musubi_tuner.utils import train_utils
+
+
+def _save_args(tmp_path):
+    return SimpleNamespace(
+        output_name="dataset",
+        output_dir=str(tmp_path),
+        save_state_to_huggingface=False,
+        save_last_n_epochs_state=None,
+        save_last_n_epochs=None,
+        save_every_n_epochs=1,
+        save_last_n_steps_state=None,
+        save_last_n_steps=None,
+        save_every_n_steps=1000,
+    )
+
+
+def test_resume_metadata_round_trip_and_corrupt_file(tmp_path):
+    train_utils.save_resume_metadata(str(tmp_path), global_step=10000, step_in_epoch=24, epoch=87)
+
+    assert train_utils.load_resume_metadata(str(tmp_path)) == {
+        "global_step": 10000,
+        "step_in_epoch": 24,
+        "epoch": 87,
+    }
+    assert not (tmp_path / f"{train_utils.RESUME_METADATA_NAME}.tmp").exists()
+
+    (tmp_path / train_utils.RESUME_METADATA_NAME).write_text("{broken", encoding="utf-8")
+    assert train_utils.load_resume_metadata(str(tmp_path)) is None
+
+
+def test_all_state_directory_types_save_resume_metadata(tmp_path):
+    args = _save_args(tmp_path)
+
+    # Create directories the same way Accelerate does before writing its payload.
+    class Accelerator:
+        def save_state(self, state_dir):
+            from pathlib import Path
+
+            Path(state_dir).mkdir(parents=True, exist_ok=True)
+
+    accelerator = Accelerator()
+    train_utils.save_and_remove_state_stepwise(args, accelerator, 10000, epoch=87, step_in_epoch=24)
+    train_utils.save_and_remove_state_on_epoch_end(args, accelerator, 87, global_step=10092, step_in_epoch=0)
+    train_utils.save_state_on_train_end(args, accelerator, global_step=10100, epoch=88, step_in_epoch=8)
+
+    expected = {
+        "dataset-step00010000-state": {"global_step": 10000, "step_in_epoch": 24, "epoch": 87},
+        "dataset-000087-state": {"global_step": 10092, "step_in_epoch": 0, "epoch": 87},
+        "dataset-state": {"global_step": 10100, "step_in_epoch": 8, "epoch": 88},
+    }
+    for dirname, metadata in expected.items():
+        path = tmp_path / dirname / train_utils.RESUME_METADATA_NAME
+        assert json.loads(path.read_text(encoding="utf-8")) == metadata
+
+
+def test_recover_global_step_prefers_metadata(tmp_path):
+    torch.save({"last_epoch": 9000}, tmp_path / "scheduler.bin")
+    train_utils.save_resume_metadata(str(tmp_path), global_step=10000, step_in_epoch=24, epoch=87)
+
+    assert recover_global_step(str(tmp_path)) == 10000
+
+
+def test_recover_global_step_from_legacy_scheduler(tmp_path):
+    torch.save({"last_epoch": 10000, "_step_count": 10001}, tmp_path / "scheduler.bin")
+
+    assert recover_global_step(str(tmp_path)) == 10000
+
+
+def test_resume_position_uses_exact_metadata_for_mid_epoch():
+    metadata = {"global_step": 10000, "epoch": 87, "step_in_epoch": 24}
+
+    assert train_utils.get_resume_position(10000, 116, metadata) == (86, 24)
+
+
+def test_fresh_training_starts_at_zero():
+    assert train_utils.get_resume_position(0, 116, None) == (0, 0)
+
+
+def test_resume_position_starts_after_epoch_end():
+    metadata = {"global_step": 10092, "epoch": 87, "step_in_epoch": 0}
+
+    assert train_utils.get_resume_position(10092, 116, metadata) == (87, 0)
+
+
+def test_legacy_resume_infers_epoch_without_claiming_batch_position():
+    assert train_utils.get_resume_position(10000, 116, None) == (86, 0)


### PR DESCRIPTION
## Problem

`accelerator.load_state()` restores model, optimizer, scheduler, RNG, and dataloader state, but the shared Musubi trainer then resets `epoch_to_start` and `global_step` to zero. This is the same application-level bookkeeping failure reported in kohya-ss/musubi-tuner#776.

The previous version of this PR used `accelerator.step` as the resumed global step. That value is Accelerate's internal accumulation/synchronization bookkeeping, not Musubi's absolute optimization counter, so this PR now replaces that approach.

## Implementation

- Save an atomic `resume_metadata.json` beside every step, epoch, and final Accelerate state.
- Record `global_step`, one-based `epoch`, and consumed dataloader batches as `step_in_epoch`.
- Recover `global_step` from metadata for new checkpoints.
- Fall back to the scheduler state's `last_epoch` value for legacy checkpoints without metadata.
- Return the recovered step from local and Hugging Face resume paths and propagate it into the shared training loop.
- Initialize `global_step`, the progress bar, and the starting epoch from the restored position.
- Resume mid-epoch checkpoints in the saved epoch and skip batches already consumed there.
- Treat `step_in_epoch=0` as an epoch boundary and start the following epoch.
- Preserve resumed checkpoint numbering and stop at the original `max_train_steps` target.
- Avoid first-run image sampling and step-zero tracker commits on resumed runs.
- Do not use directory-name parsing or `accelerator.step`.

Generic `<output_name>-state` directories are now self-describing, and existing H3 states remain compatible through the scheduler fallback. A legacy state whose scheduler has `last_epoch=10000` resumes at step 10000; with `max_train_steps=70000`, only 60000 additional optimizer updates are performed and the next 1000-step state is numbered step 11000.

## Tests

Added focused tests covering:

- fresh training position
- atomic metadata round-trip and corrupt metadata handling
- step, epoch, and generic final-state metadata
- metadata precedence over scheduler state
- legacy scheduler recovery
- exact mid-epoch position restoration
- epoch-end restoration
- legacy epoch inference without pretending to know the batch offset

Result: `8 passed`.