### PR TITLE
Add --ltx2_gpu_load and blocks_to_checkpoint fallback

### DIFF
--- a/src/musubi_tuner/ltx2_args.py
+++ b/src/musubi_tuner/ltx2_args.py
@@ -96,6 +96,11 @@ def add_ltx2_performance_args(parser: argparse.ArgumentParser) -> argparse.Argum
             "--ltx2_block_swap_trainable_ring",
             "Coalesce trainable FFT block transfers through a preallocated pinned/GPU ring.",
         ),
+        (
+            "--ltx2_gpu_load",
+            "Load the transformer directly onto the GPU even when --blocks_to_swap is set. "
+            "Skips the CPU-staging round trip for faster startup on high-VRAM cards.",
+        ),
     )
     for option, help_text in flags:
         group.add_argument(option, action="store_true", default=None, help=help_text)

--- a/src/musubi_tuner/ltx2_train.py
+++ b/src/musubi_tuner/ltx2_train.py
@@ -3821,9 +3821,20 @@ def main() -> None:
     # int8 model to the GPU. This lets int8-weight FFT fit without --blocks_to_swap (which is slow).
     # The resulting Int8QTWeight is identical to converting on the GPU (from_float is deterministic).
     int8_weights_cpu_load = bool(getattr(args, "int8_weights", False))
+    # --ltx2_gpu_load loads the transformer directly onto the GPU even when block swap is enabled:
+    # on high-VRAM cards the CPU-staging round trip costs more wall-clock time than the peak-VRAM
+    # it saves. The remaining conditions are explicit opt-ins or memory-bounded features that
+    # require CPU loading regardless.
+    gpu_load = bool(getattr(args, "ltx2_gpu_load", False))
+    if gpu_load and blocks_to_swap > 0:
+        logger.info("--ltx2_gpu_load: loading transformer directly onto %s despite --blocks_to_swap", accelerator.device)
     loading_device = (
         "cpu"
-        if blocks_to_swap > 0 or ltx2_model_parallel or remote_prune_local_blocks or qgalore_cpu_load or int8_weights_cpu_load
+        if (blocks_to_swap > 0 and not gpu_load)
+        or ltx2_model_parallel
+        or remote_prune_local_blocks
+        or qgalore_cpu_load
+        or int8_weights_cpu_load
         else accelerator.device
     )
     if qgalore_cpu_load:

--- a/src/musubi_tuner/training/training_loop.py
+++ b/src/musubi_tuner/training/training_loop.py
@@ -534,9 +534,17 @@ def train(self, args):
     if args.gradient_checkpointing:
         blocks_to_ckpt = getattr(args, "blocks_to_checkpoint", -1)
         if getattr(args, "blockwise_checkpointing", False):
-            transformer.enable_gradient_checkpointing(
-                args.gradient_checkpointing_cpu_offload, weight_cpu_offloading=True, blocks_to_checkpoint=blocks_to_ckpt
-            )
+            try:
+                transformer.enable_gradient_checkpointing(
+                    args.gradient_checkpointing_cpu_offload, weight_cpu_offloading=True, blocks_to_checkpoint=blocks_to_ckpt
+                )
+            except TypeError:
+                logger.warning(
+                    "Transformer %s does not support blocks_to_checkpoint / weight_cpu_offloading; "
+                    "falling back to basic gradient checkpointing.",
+                    type(transformer).__name__,
+                )
+                transformer.enable_gradient_checkpointing(args.gradient_checkpointing_cpu_offload)
             if hasattr(transformer, "transformer_blocks"):
                 total_blocks = len(transformer.transformer_blocks)
                 if blocks_to_ckpt is None or int(blocks_to_ckpt) == -1:
@@ -556,7 +564,14 @@ def train(self, args):
                     if hasattr(block, "use_pinned_memory"):
                         block.use_pinned_memory = True
         else:
-            transformer.enable_gradient_checkpointing(args.gradient_checkpointing_cpu_offload, blocks_to_checkpoint=blocks_to_ckpt)
+            try:
+                transformer.enable_gradient_checkpointing(args.gradient_checkpointing_cpu_offload, blocks_to_checkpoint=blocks_to_ckpt)
+            except TypeError:
+                logger.warning(
+                    "Transformer %s does not support blocks_to_checkpoint; falling back to basic gradient checkpointing.",
+                    type(transformer).__name__,
+                )
+                transformer.enable_gradient_checkpointing(args.gradient_checkpointing_cpu_offload)
         try:
             network.enable_gradient_checkpointing(
                 args.gradient_checkpointing_cpu_offload,


### PR DESCRIPTION
## Summary

Two small, independent changes:

### 1. New opt-in `--ltx2_gpu_load` flag (LTX-2 full fine-tuning)

When `--blocks_to_swap` is set, the transformer is currently loaded onto CPU first and then staged through block swap. On high-VRAM cards that CPU-staging round trip costs more wall-clock time than the peak-VRAM it saves.

`--ltx2_gpu_load` loads the transformer directly onto the GPU in that case. The flag is purely opt-in; default behavior is unchanged, and the other CPU-loading conditions (model parallel, remote-stage pruning, `--qgalore_load_device cpu`, `--int8_weights`) still take precedence.

### 2. TypeError fallback for `blocks_to_checkpoint` in the shared training loop

`training/training_loop.py` calls `transformer.enable_gradient_checkpointing(..., blocks_to_checkpoint=...)` (and `weight_cpu_offloading=...` in the blockwise branch) unguarded for every architecture, but only the LTX-2 transformer accepts those kwargs. Architectures like HunyuanVideo (`HYVideoDiffusionTransformer.enable_gradient_checkpointing(self, activation_cpu_offloading=False)`) raise `TypeError` when `--gradient_checkpointing` is used.

The network-side call right below is already wrapped in `try/except TypeError`; this applies the same guard to the two transformer-side calls, falling back to basic gradient checkpointing with a warning.