### PR TITLE
Unify checkpoint retention into a single keep-last-N option

### DIFF
--- a/src/musubi_tuner/gui_dashboard/command_builder.py
+++ b/src/musubi_tuner/gui_dashboard/command_builder.py
@@ -853,8 +853,6 @@ def _build_h3_training_cmd(config: ProjectConfig) -> list[str]:
         cmd += ["--save_every_n_steps", str(t.save_every_n_steps)]
     if t.save_last_n_checkpoints is not None:
         cmd += ["--save_last_n_checkpoints", str(t.save_last_n_checkpoints)]
-    if t.save_last_n_checkpoints_state is not None:
-        cmd += ["--save_last_n_checkpoints_state", str(t.save_last_n_checkpoints_state)]
     if t.async_checkpoint_save:
         cmd.append("--async_checkpoint_save")
     if t.save_state:
@@ -2309,8 +2307,6 @@ def build_training_cmd(config: ProjectConfig) -> list[str]:
         cmd += ["--save_every_n_steps", str(t.save_every_n_steps)]
     if t.save_last_n_checkpoints is not None:
         cmd += ["--save_last_n_checkpoints", str(t.save_last_n_checkpoints)]
-    if t.save_last_n_checkpoints_state is not None:
-        cmd += ["--save_last_n_checkpoints_state", str(t.save_last_n_checkpoints_state)]
     if t.save_state:
         cmd.append("--save_state")
     if t.save_state_on_train_end:
@@ -3260,8 +3256,6 @@ def build_full_finetune_cmd(config: ProjectConfig) -> list[str]:
         cmd += ["--save_every_n_steps", str(t.save_every_n_steps)]
     if t.save_last_n_checkpoints is not None:
         cmd += ["--save_last_n_checkpoints", str(t.save_last_n_checkpoints)]
-    if t.save_last_n_checkpoints_state is not None:
-        cmd += ["--save_last_n_checkpoints_state", str(t.save_last_n_checkpoints_state)]
     if t.save_state:
         cmd.append("--save_state")
     if t.save_state_on_train_end:
@@ -3714,8 +3708,6 @@ def build_slider_training_cmd(config: ProjectConfig) -> list[str]:
         cmd += ["--save_every_n_steps", str(t.save_every_n_steps)]
     if t.save_last_n_checkpoints is not None:
         cmd += ["--save_last_n_checkpoints", str(t.save_last_n_checkpoints)]
-    if t.save_last_n_checkpoints_state is not None:
-        cmd += ["--save_last_n_checkpoints_state", str(t.save_last_n_checkpoints_state)]
     if t.save_state:
         cmd.append("--save_state")
     if t.save_state_on_train_end:

--- a/src/musubi_tuner/gui_dashboard/command_builder.py
+++ b/src/musubi_tuner/gui_dashboard/command_builder.py
@@ -851,14 +851,10 @@ def _build_h3_training_cmd(config: ProjectConfig) -> list[str]:
         cmd += ["--save_every_n_epochs", str(t.save_every_n_epochs)]
     if t.save_every_n_steps:
         cmd += ["--save_every_n_steps", str(t.save_every_n_steps)]
-    if t.save_last_n_epochs is not None:
-        cmd += ["--save_last_n_epochs", str(t.save_last_n_epochs)]
-    if t.save_last_n_steps is not None:
-        cmd += ["--save_last_n_steps", str(t.save_last_n_steps)]
-    if t.save_last_n_epochs_state is not None:
-        cmd += ["--save_last_n_epochs_state", str(t.save_last_n_epochs_state)]
-    if t.save_last_n_steps_state is not None:
-        cmd += ["--save_last_n_steps_state", str(t.save_last_n_steps_state)]
+    if t.save_last_n_checkpoints is not None:
+        cmd += ["--save_last_n_checkpoints", str(t.save_last_n_checkpoints)]
+    if t.save_last_n_checkpoints_state is not None:
+        cmd += ["--save_last_n_checkpoints_state", str(t.save_last_n_checkpoints_state)]
     if t.async_checkpoint_save:
         cmd.append("--async_checkpoint_save")
     if t.save_state:
@@ -2311,14 +2307,10 @@ def build_training_cmd(config: ProjectConfig) -> list[str]:
         cmd += ["--save_every_n_epochs", str(t.save_every_n_epochs)]
     if t.save_every_n_steps:
         cmd += ["--save_every_n_steps", str(t.save_every_n_steps)]
-    if t.save_last_n_epochs is not None:
-        cmd += ["--save_last_n_epochs", str(t.save_last_n_epochs)]
-    if t.save_last_n_steps is not None:
-        cmd += ["--save_last_n_steps", str(t.save_last_n_steps)]
-    if t.save_last_n_epochs_state is not None:
-        cmd += ["--save_last_n_epochs_state", str(t.save_last_n_epochs_state)]
-    if t.save_last_n_steps_state is not None:
-        cmd += ["--save_last_n_steps_state", str(t.save_last_n_steps_state)]
+    if t.save_last_n_checkpoints is not None:
+        cmd += ["--save_last_n_checkpoints", str(t.save_last_n_checkpoints)]
+    if t.save_last_n_checkpoints_state is not None:
+        cmd += ["--save_last_n_checkpoints_state", str(t.save_last_n_checkpoints_state)]
     if t.save_state:
         cmd.append("--save_state")
     if t.save_state_on_train_end:
@@ -3266,10 +3258,10 @@ def build_full_finetune_cmd(config: ProjectConfig) -> list[str]:
         cmd += ["--save_every_n_epochs", str(t.save_every_n_epochs)]
     if t.save_every_n_steps:
         cmd += ["--save_every_n_steps", str(t.save_every_n_steps)]
-    if t.save_last_n_epochs is not None:
-        cmd += ["--save_last_n_epochs", str(t.save_last_n_epochs)]
-    if t.save_last_n_steps is not None:
-        cmd += ["--save_last_n_steps", str(t.save_last_n_steps)]
+    if t.save_last_n_checkpoints is not None:
+        cmd += ["--save_last_n_checkpoints", str(t.save_last_n_checkpoints)]
+    if t.save_last_n_checkpoints_state is not None:
+        cmd += ["--save_last_n_checkpoints_state", str(t.save_last_n_checkpoints_state)]
     if t.save_state:
         cmd.append("--save_state")
     if t.save_state_on_train_end:
@@ -3720,10 +3712,10 @@ def build_slider_training_cmd(config: ProjectConfig) -> list[str]:
         cmd += ["--output_name", s.output_name]
     if t.save_every_n_steps:
         cmd += ["--save_every_n_steps", str(t.save_every_n_steps)]
-    if t.save_last_n_steps is not None:
-        cmd += ["--save_last_n_steps", str(t.save_last_n_steps)]
-    if t.save_last_n_steps_state is not None:
-        cmd += ["--save_last_n_steps_state", str(t.save_last_n_steps_state)]
+    if t.save_last_n_checkpoints is not None:
+        cmd += ["--save_last_n_checkpoints", str(t.save_last_n_checkpoints)]
+    if t.save_last_n_checkpoints_state is not None:
+        cmd += ["--save_last_n_checkpoints_state", str(t.save_last_n_checkpoints_state)]
     if t.save_state:
         cmd.append("--save_state")
     if t.save_state_on_train_end:

--- a/src/musubi_tuner/gui_dashboard/frontend/src/routes/training/+page.svelte
+++ b/src/musubi_tuner/gui_dashboard/frontend/src/routes/training/+page.svelte
@@ -1211,8 +1211,7 @@
 						</div>
 						{#if $advancedMode}
 						<div class="grid grid-cols-2 gap-2">
-							<FormField type="number" fieldPath="training.save_last_n_checkpoints" value={t.save_last_n_checkpoints ?? ''} oninput={(e) => update('save_last_n_checkpoints', e.target.value ? Number(e.target.value) : null)} placeholder="All" tooltip="Keep only the last N checkpoints, whether saving by epoch or by step" />
-							<FormField type="number" fieldPath="training.save_last_n_checkpoints_state" value={t.save_last_n_checkpoints_state ?? ''} oninput={(e) => update('save_last_n_checkpoints_state', e.target.value ? Number(e.target.value) : null)} placeholder="All" tooltip="Keep only the last N checkpoint states (overrides the checkpoint count)" />
+							<FormField type="number" fieldPath="training.save_last_n_checkpoints" value={t.save_last_n_checkpoints ?? ''} oninput={(e) => update('save_last_n_checkpoints', e.target.value ? Number(e.target.value) : null)} placeholder="All" tooltip="Keep only the last N checkpoints (and their matching states), whether saving by epoch or by step" />
 						</div>
 						<div class="grid grid-cols-3 gap-x-4 gap-y-1">
 							<FormToggle label="Async checkpoint save" fieldPath="training.async_checkpoint_save" checked={t.async_checkpoint_save ?? false} onchange={(e) => update('async_checkpoint_save', e.target.checked)} tooltip="Snapshot periodic checkpoints to CPU and write them on a background thread. Reduces save pauses at the cost of roughly one checkpoint of additional system RAM; the final checkpoint and saved state stay synchronous." />

--- a/src/musubi_tuner/gui_dashboard/frontend/src/routes/training/+page.svelte
+++ b/src/musubi_tuner/gui_dashboard/frontend/src/routes/training/+page.svelte
@@ -1211,12 +1211,8 @@
 						</div>
 						{#if $advancedMode}
 						<div class="grid grid-cols-2 gap-2">
-							<FormField type="number" fieldPath="training.save_last_n_epochs" value={t.save_last_n_epochs ?? ''} oninput={(e) => update('save_last_n_epochs', e.target.value ? Number(e.target.value) : null)} placeholder="All" tooltip="Only keep last N epoch checkpoints" />
-							<FormField type="number" fieldPath="training.save_last_n_steps" value={t.save_last_n_steps ?? ''} oninput={(e) => update('save_last_n_steps', e.target.value ? Number(e.target.value) : null)} placeholder="All" tooltip="Only keep last N step checkpoints" />
-						</div>
-						<div class="grid grid-cols-2 gap-2">
-							<FormField type="number" fieldPath="training.save_last_n_epochs_state" value={t.save_last_n_epochs_state ?? ''} oninput={(e) => update('save_last_n_epochs_state', e.target.value ? Number(e.target.value) : null)} placeholder="All" tooltip="Only keep last N epoch optimizer states" />
-							<FormField type="number" fieldPath="training.save_last_n_steps_state" value={t.save_last_n_steps_state ?? ''} oninput={(e) => update('save_last_n_steps_state', e.target.value ? Number(e.target.value) : null)} placeholder="All" tooltip="Only keep last N step optimizer states" />
+							<FormField type="number" fieldPath="training.save_last_n_checkpoints" value={t.save_last_n_checkpoints ?? ''} oninput={(e) => update('save_last_n_checkpoints', e.target.value ? Number(e.target.value) : null)} placeholder="All" tooltip="Keep only the last N checkpoints, whether saving by epoch or by step" />
+							<FormField type="number" fieldPath="training.save_last_n_checkpoints_state" value={t.save_last_n_checkpoints_state ?? ''} oninput={(e) => update('save_last_n_checkpoints_state', e.target.value ? Number(e.target.value) : null)} placeholder="All" tooltip="Keep only the last N checkpoint states (overrides the checkpoint count)" />
 						</div>
 						<div class="grid grid-cols-3 gap-x-4 gap-y-1">
 							<FormToggle label="Async checkpoint save" fieldPath="training.async_checkpoint_save" checked={t.async_checkpoint_save ?? false} onchange={(e) => update('async_checkpoint_save', e.target.checked)} tooltip="Snapshot periodic checkpoints to CPU and write them on a background thread. Reduces save pauses at the cost of roughly one checkpoint of additional system RAM; the final checkpoint and saved state stay synchronous." />

--- a/src/musubi_tuner/gui_dashboard/frontend/src/routes/training/full-finetune/+page.svelte
+++ b/src/musubi_tuner/gui_dashboard/frontend/src/routes/training/full-finetune/+page.svelte
@@ -842,9 +842,8 @@
 				</div>
 				<div class="grid grid-cols-2 gap-2">
 					<FormField type="number" fieldPath="full_finetune.save_every_n_steps" value={t.save_every_n_steps ?? ''} oninput={(e) => update('save_every_n_steps', numberOrNull(e.target.value))} min={1} />
-					<FormField type="number" fieldPath="full_finetune.save_last_n_checkpoints" value={t.save_last_n_checkpoints ?? ''} oninput={(e) => update('save_last_n_checkpoints', numberOrNull(e.target.value))} min={0} tooltip="Keep only the last N checkpoints, whether saving by epoch or by step" />
+					<FormField type="number" fieldPath="full_finetune.save_last_n_checkpoints" value={t.save_last_n_checkpoints ?? ''} oninput={(e) => update('save_last_n_checkpoints', numberOrNull(e.target.value))} min={0} tooltip="Keep only the last N checkpoints (and their matching states), whether saving by epoch or by step" />
 					<FormField type="number" fieldPath="full_finetune.save_every_n_epochs" value={t.save_every_n_epochs ?? ''} oninput={(e) => update('save_every_n_epochs', numberOrNull(e.target.value))} min={1} />
-					<FormField type="number" fieldPath="full_finetune.save_last_n_checkpoints_state" value={t.save_last_n_checkpoints_state ?? ''} oninput={(e) => update('save_last_n_checkpoints_state', numberOrNull(e.target.value))} min={0} tooltip="Keep only the last N checkpoint states (overrides the checkpoint count)" />
 				</div>
 				<div class="grid grid-cols-2 gap-x-4 gap-y-1">
 					<FormToggle fieldPath="full_finetune.save_state" checked={t.save_state ?? false} onchange={(e) => update('save_state', e.target.checked)} />

--- a/src/musubi_tuner/gui_dashboard/frontend/src/routes/training/full-finetune/+page.svelte
+++ b/src/musubi_tuner/gui_dashboard/frontend/src/routes/training/full-finetune/+page.svelte
@@ -842,9 +842,9 @@
 				</div>
 				<div class="grid grid-cols-2 gap-2">
 					<FormField type="number" fieldPath="full_finetune.save_every_n_steps" value={t.save_every_n_steps ?? ''} oninput={(e) => update('save_every_n_steps', numberOrNull(e.target.value))} min={1} />
-					<FormField type="number" fieldPath="full_finetune.save_last_n_steps" value={t.save_last_n_steps ?? ''} oninput={(e) => update('save_last_n_steps', numberOrNull(e.target.value))} min={0} />
+					<FormField type="number" fieldPath="full_finetune.save_last_n_checkpoints" value={t.save_last_n_checkpoints ?? ''} oninput={(e) => update('save_last_n_checkpoints', numberOrNull(e.target.value))} min={0} tooltip="Keep only the last N checkpoints, whether saving by epoch or by step" />
 					<FormField type="number" fieldPath="full_finetune.save_every_n_epochs" value={t.save_every_n_epochs ?? ''} oninput={(e) => update('save_every_n_epochs', numberOrNull(e.target.value))} min={1} />
-					<FormField type="number" fieldPath="full_finetune.save_last_n_epochs" value={t.save_last_n_epochs ?? ''} oninput={(e) => update('save_last_n_epochs', numberOrNull(e.target.value))} min={0} />
+					<FormField type="number" fieldPath="full_finetune.save_last_n_checkpoints_state" value={t.save_last_n_checkpoints_state ?? ''} oninput={(e) => update('save_last_n_checkpoints_state', numberOrNull(e.target.value))} min={0} tooltip="Keep only the last N checkpoint states (overrides the checkpoint count)" />
 				</div>
 				<div class="grid grid-cols-2 gap-x-4 gap-y-1">
 					<FormToggle fieldPath="full_finetune.save_state" checked={t.save_state ?? false} onchange={(e) => update('save_state', e.target.checked)} />

--- a/src/musubi_tuner/gui_dashboard/project_schema.py
+++ b/src/musubi_tuner/gui_dashboard/project_schema.py
@@ -1654,6 +1654,16 @@ class ProjectConfig(BaseModel):
                 full_finetune = dict(full_finetune)
                 if not full_finetune.get("output_dir"):
                     full_finetune["output_dir"] = get_ltx2_training_output_dir_default()
+                # Same retention fold as the training section above.
+                for legacy, unified in (
+                    ("save_last_n_steps", "save_last_n_checkpoints"),
+                    ("save_last_n_epochs", "save_last_n_checkpoints"),
+                    ("save_last_n_steps_state", "save_last_n_checkpoints_state"),
+                    ("save_last_n_epochs_state", "save_last_n_checkpoints_state"),
+                ):
+                    value = full_finetune.pop(legacy, None)
+                    if value is not None and full_finetune.get(unified) is None:
+                        full_finetune[unified] = value
                 data["full_finetune"] = full_finetune
 
             for section_name in ("caching", "training", "full_finetune", "remote_stage_server", "inference"):

--- a/src/musubi_tuner/gui_dashboard/project_schema.py
+++ b/src/musubi_tuner/gui_dashboard/project_schema.py
@@ -714,10 +714,8 @@ class TrainingConfig(BaseModel):
     output_name: str = "minimax_h3_lora"
     save_every_n_epochs: Optional[int] = None
     save_every_n_steps: Optional[int] = None
-    save_last_n_epochs: Optional[int] = None
-    save_last_n_steps: Optional[int] = None
-    save_last_n_epochs_state: Optional[int] = None
-    save_last_n_steps_state: Optional[int] = None
+    save_last_n_checkpoints: Optional[int] = None
+    save_last_n_checkpoints_state: Optional[int] = None
     async_checkpoint_save: bool = False
     save_state: bool = False
     save_state_mode: Literal["full", "minimal"] = "full"
@@ -1632,6 +1630,17 @@ class ProjectConfig(BaseModel):
                     training["output_dir"] = get_ltx2_training_output_dir_default()
                 if not training.get("network_module"):
                     training["network_module"] = get_ltx2_training_network_module_default()
+                # Unified retention: legacy keep-last fields all meant "how many checkpoints
+                # to keep" — fold them into save_last_n_checkpoints(_state).
+                for legacy, unified in (
+                    ("save_last_n_steps", "save_last_n_checkpoints"),
+                    ("save_last_n_epochs", "save_last_n_checkpoints"),
+                    ("save_last_n_steps_state", "save_last_n_checkpoints_state"),
+                    ("save_last_n_epochs_state", "save_last_n_checkpoints_state"),
+                ):
+                    value = training.pop(legacy, None)
+                    if value is not None and training.get(unified) is None:
+                        training[unified] = value
                 data["training"] = training
 
             model_dir = data.get("model_dir") or None

--- a/src/musubi_tuner/gui_dashboard/project_schema.py
+++ b/src/musubi_tuner/gui_dashboard/project_schema.py
@@ -715,7 +715,6 @@ class TrainingConfig(BaseModel):
     save_every_n_epochs: Optional[int] = None
     save_every_n_steps: Optional[int] = None
     save_last_n_checkpoints: Optional[int] = None
-    save_last_n_checkpoints_state: Optional[int] = None
     async_checkpoint_save: bool = False
     save_state: bool = False
     save_state_mode: Literal["full", "minimal"] = "full"
@@ -1631,16 +1630,12 @@ class ProjectConfig(BaseModel):
                 if not training.get("network_module"):
                     training["network_module"] = get_ltx2_training_network_module_default()
                 # Unified retention: legacy keep-last fields all meant "how many checkpoints
-                # to keep" — fold them into save_last_n_checkpoints(_state).
-                for legacy, unified in (
-                    ("save_last_n_steps", "save_last_n_checkpoints"),
-                    ("save_last_n_epochs", "save_last_n_checkpoints"),
-                    ("save_last_n_steps_state", "save_last_n_checkpoints_state"),
-                    ("save_last_n_epochs_state", "save_last_n_checkpoints_state"),
-                ):
+                # to keep" — fold them into save_last_n_checkpoints. States are pruned in
+                # lockstep with their checkpoints, so there is only one count.
+                for legacy in ("save_last_n_steps", "save_last_n_epochs", "save_last_n_steps_state", "save_last_n_epochs_state"):
                     value = training.pop(legacy, None)
-                    if value is not None and training.get(unified) is None:
-                        training[unified] = value
+                    if value is not None and training.get("save_last_n_checkpoints") is None:
+                        training["save_last_n_checkpoints"] = value
                 data["training"] = training
 
             model_dir = data.get("model_dir") or None
@@ -1655,15 +1650,10 @@ class ProjectConfig(BaseModel):
                 if not full_finetune.get("output_dir"):
                     full_finetune["output_dir"] = get_ltx2_training_output_dir_default()
                 # Same retention fold as the training section above.
-                for legacy, unified in (
-                    ("save_last_n_steps", "save_last_n_checkpoints"),
-                    ("save_last_n_epochs", "save_last_n_checkpoints"),
-                    ("save_last_n_steps_state", "save_last_n_checkpoints_state"),
-                    ("save_last_n_epochs_state", "save_last_n_checkpoints_state"),
-                ):
+                for legacy in ("save_last_n_steps", "save_last_n_epochs", "save_last_n_steps_state", "save_last_n_epochs_state"):
                     value = full_finetune.pop(legacy, None)
-                    if value is not None and full_finetune.get(unified) is None:
-                        full_finetune[unified] = value
+                    if value is not None and full_finetune.get("save_last_n_checkpoints") is None:
+                        full_finetune["save_last_n_checkpoints"] = value
                 data["full_finetune"] = full_finetune
 
             for section_name in ("caching", "training", "full_finetune", "remote_stage_server", "inference"):

--- a/src/musubi_tuner/gui_dashboard/routers/stats.py
+++ b/src/musubi_tuner/gui_dashboard/routers/stats.py
@@ -669,12 +669,14 @@ def _calculate_training_stats(config: dict, dataset_stats: DatasetStats | None) 
             total_checkpoints += int(total_epochs) // save_every_n_epochs
 
         # Apply keep_last limits
-        keep_last_steps = _coerce_int(training.get("save_last_n_steps", 0), 0)
-        keep_last_epochs = _coerce_int(training.get("save_last_n_epochs", 0), 0)
-        if keep_last_steps:
-            total_checkpoints = min(total_checkpoints, keep_last_steps + 1)
-        if keep_last_epochs:
-            total_checkpoints = min(total_checkpoints, keep_last_epochs + 1)
+        keep_last = _coerce_int(
+            training.get("save_last_n_checkpoints")
+            or training.get("save_last_n_steps")
+            or training.get("save_last_n_epochs"),
+            0,
+        )
+        if keep_last:
+            total_checkpoints = min(total_checkpoints, keep_last)
 
         total_storage_gb = (checkpoint_size_mb * total_checkpoints) / 1024
 

--- a/src/musubi_tuner/hidream_o1_train.py
+++ b/src/musubi_tuner/hidream_o1_train.py
@@ -555,7 +555,7 @@ class HiDreamO1Trainer(HiDreamO1NetworkTrainer):
                                 if args.save_state:
                                     train_utils.save_and_remove_state_stepwise(args, accelerator, global_step)
 
-                                remove_step_no = train_utils.get_remove_step_no(args, global_step)
+                                remove_step_no = train_utils.get_remove_ckpt_no(args, global_step, args.save_every_n_steps)
                                 if remove_step_no is not None:
                                     remove_ckpt_name = train_utils.get_step_ckpt_name(args.output_name, remove_step_no)
                                     remove_model(remove_ckpt_name)
@@ -594,7 +594,7 @@ class HiDreamO1Trainer(HiDreamO1NetworkTrainer):
                         use_memory_efficient_saving=args.mem_eff_save,
                     )
 
-                    remove_epoch_no = train_utils.get_remove_epoch_no(args, epoch + 1)
+                    remove_epoch_no = train_utils.get_remove_ckpt_no(args, epoch + 1, args.save_every_n_epochs)
                     if remove_epoch_no is not None:
                         remove_ckpt_name = train_utils.get_epoch_ckpt_name(args.output_name, remove_epoch_no)
                         remove_model(remove_ckpt_name)

--- a/src/musubi_tuner/hv_train.py
+++ b/src/musubi_tuner/hv_train.py
@@ -1129,7 +1129,7 @@ class FineTuningTrainer:
                             if args.save_state:
                                 train_utils.save_and_remove_state_stepwise(args, accelerator, global_step)
 
-                            remove_step_no = train_utils.get_remove_step_no(args, global_step)
+                            remove_step_no = train_utils.get_remove_ckpt_no(args, global_step, args.save_every_n_steps)
                             if remove_step_no is not None:
                                 remove_ckpt_name = train_utils.get_step_ckpt_name(args.output_name, remove_step_no)
                                 remove_model(remove_ckpt_name)
@@ -1162,7 +1162,7 @@ class FineTuningTrainer:
                     ckpt_name = train_utils.get_epoch_ckpt_name(args.output_name, epoch + 1)
                     save_model(ckpt_name, accelerator.unwrap_model(transformer), global_step, epoch + 1)
 
-                    remove_epoch_no = train_utils.get_remove_epoch_no(args, epoch + 1)
+                    remove_epoch_no = train_utils.get_remove_ckpt_no(args, epoch + 1, args.save_every_n_epochs)
                     if remove_epoch_no is not None:
                         remove_ckpt_name = train_utils.get_epoch_ckpt_name(args.output_name, remove_epoch_no)
                         remove_model(remove_ckpt_name)
@@ -1565,28 +1565,44 @@ def setup_parser() -> argparse.ArgumentParser:
         help="save checkpoint every N steps / 学習中のモデルを指定ステップごとに保存する",
     )
     parser.add_argument(
+        "--save_last_n_checkpoints",
+        type=int,
+        default=None,
+        help="keep only the last N checkpoints on disk, whether saving every N epochs or every N steps"
+        " / エポック保存でもステップ保存でも、最新N個のチェックポイントだけを残す（古いものは削除する）",
+    )
+    parser.add_argument(
+        "--save_last_n_checkpoints_state",
+        type=int,
+        default=None,
+        help="keep only the last N checkpoint states (overrides --save_last_n_checkpoints)"
+        " / 最新N個のstateだけを残す（--save_last_n_checkpointsの指定を上書きする）",
+    )
+    # Legacy retention flags, kept as aliases of --save_last_n_checkpoints(_state): they all
+    # mean "how many checkpoints to keep" now, so old configs keep working with count semantics.
+    parser.add_argument(
         "--save_last_n_epochs",
         type=int,
         default=None,
-        help="save last N checkpoints when saving every N epochs (remove older checkpoints) / 指定エポックごとにモデルを保存するとき最大Nエポック保存する（古いチェックポイントは削除する）",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--save_last_n_epochs_state",
         type=int,
         default=None,
-        help="save last N checkpoints of state (overrides the value of --save_last_n_epochs)/ 最大Nエポックstateを保存する（--save_last_n_epochsの指定を上書きする）",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--save_last_n_steps",
         type=int,
         default=None,
-        help="save checkpoints until N steps elapsed (remove older checkpoints if N steps elapsed) / 指定ステップごとにモデルを保存するとき、このステップ数経過するまで保存する（このステップ数経過したら削除する）",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--save_last_n_steps_state",
         type=int,
         default=None,
-        help="save states until N steps elapsed (remove older states if N steps elapsed, overrides --save_last_n_steps) / 指定ステップごとにstateを保存するとき、このステップ数経過するまで保存する（このステップ数経過したら削除する。--save_last_n_stepsを上書きする）",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--save_state",

--- a/src/musubi_tuner/hv_train.py
+++ b/src/musubi_tuner/hv_train.py
@@ -1568,17 +1568,11 @@ def setup_parser() -> argparse.ArgumentParser:
         "--save_last_n_checkpoints",
         type=int,
         default=None,
-        help="keep only the last N checkpoints on disk, whether saving every N epochs or every N steps"
-        " / エポック保存でもステップ保存でも、最新N個のチェックポイントだけを残す（古いものは削除する）",
+        help="keep only the last N checkpoints on disk (and their matching states), whether saving"
+        " every N epochs or every N steps / エポック保存でもステップ保存でも、最新N個のチェックポイント"
+        "（と対になるstate）だけを残す（古いものは削除する）",
     )
-    parser.add_argument(
-        "--save_last_n_checkpoints_state",
-        type=int,
-        default=None,
-        help="keep only the last N checkpoint states (overrides --save_last_n_checkpoints)"
-        " / 最新N個のstateだけを残す（--save_last_n_checkpointsの指定を上書きする）",
-    )
-    # Legacy retention flags, kept as aliases of --save_last_n_checkpoints(_state): they all
+    # Legacy retention flags, kept as hidden aliases of --save_last_n_checkpoints: they all
     # mean "how many checkpoints to keep" now, so old configs keep working with count semantics.
     parser.add_argument(
         "--save_last_n_epochs",

--- a/src/musubi_tuner/qwen_image_train.py
+++ b/src/musubi_tuner/qwen_image_train.py
@@ -681,7 +681,7 @@ class QwenImageTrainer(QwenImageNetworkTrainer):
                                 if args.save_state:
                                     train_utils.save_and_remove_state_stepwise(args, accelerator, global_step)
 
-                                remove_step_no = train_utils.get_remove_step_no(args, global_step)
+                                remove_step_no = train_utils.get_remove_ckpt_no(args, global_step, args.save_every_n_steps)
                                 if remove_step_no is not None:
                                     remove_ckpt_name = train_utils.get_step_ckpt_name(args.output_name, remove_step_no)
                                     remove_model(remove_ckpt_name)
@@ -722,7 +722,7 @@ class QwenImageTrainer(QwenImageNetworkTrainer):
                         use_memory_efficient_saving=args.mem_eff_save,
                     )
 
-                    remove_epoch_no = train_utils.get_remove_epoch_no(args, epoch + 1)
+                    remove_epoch_no = train_utils.get_remove_ckpt_no(args, epoch + 1, args.save_every_n_epochs)
                     if remove_epoch_no is not None:
                         remove_ckpt_name = train_utils.get_epoch_ckpt_name(args.output_name, remove_epoch_no)
                         remove_model(remove_ckpt_name)

--- a/src/musubi_tuner/training/parser_common.py
+++ b/src/musubi_tuner/training/parser_common.py
@@ -714,17 +714,11 @@ def _add_save_load_args(parser: argparse.ArgumentParser) -> None:
         "--save_last_n_checkpoints",
         type=int,
         default=None,
-        help="keep only the last N checkpoints on disk, whether saving every N epochs or every N steps"
-        " / エポック保存でもステップ保存でも、最新N個のチェックポイントだけを残す（古いものは削除する）",
+        help="keep only the last N checkpoints on disk (and their matching states), whether saving"
+        " every N epochs or every N steps / エポック保存でもステップ保存でも、最新N個のチェックポイント"
+        "（と対になるstate）だけを残す（古いものは削除する）",
     )
-    parser.add_argument(
-        "--save_last_n_checkpoints_state",
-        type=int,
-        default=None,
-        help="keep only the last N checkpoint states (overrides --save_last_n_checkpoints)"
-        " / 最新N個のstateだけを残す（--save_last_n_checkpointsの指定を上書きする）",
-    )
-    # Legacy retention flags, kept as aliases of --save_last_n_checkpoints(_state): they all
+    # Legacy retention flags, kept as hidden aliases of --save_last_n_checkpoints: they all
     # mean "how many checkpoints to keep" now, so old configs keep working with count semantics.
     parser.add_argument(
         "--save_last_n_epochs",

--- a/src/musubi_tuner/training/parser_common.py
+++ b/src/musubi_tuner/training/parser_common.py
@@ -711,28 +711,44 @@ def _add_save_load_args(parser: argparse.ArgumentParser) -> None:
         ),
     )
     parser.add_argument(
+        "--save_last_n_checkpoints",
+        type=int,
+        default=None,
+        help="keep only the last N checkpoints on disk, whether saving every N epochs or every N steps"
+        " / エポック保存でもステップ保存でも、最新N個のチェックポイントだけを残す（古いものは削除する）",
+    )
+    parser.add_argument(
+        "--save_last_n_checkpoints_state",
+        type=int,
+        default=None,
+        help="keep only the last N checkpoint states (overrides --save_last_n_checkpoints)"
+        " / 最新N個のstateだけを残す（--save_last_n_checkpointsの指定を上書きする）",
+    )
+    # Legacy retention flags, kept as aliases of --save_last_n_checkpoints(_state): they all
+    # mean "how many checkpoints to keep" now, so old configs keep working with count semantics.
+    parser.add_argument(
         "--save_last_n_epochs",
         type=int,
         default=None,
-        help="save last N checkpoints when saving every N epochs (remove older checkpoints) / 指定エポックごとにモデルを保存するとき最大Nエポック保存する（古いチェックポイントは削除する）",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--save_last_n_epochs_state",
         type=int,
         default=None,
-        help="save last N checkpoints of state (overrides the value of --save_last_n_epochs)/ 最大Nエポックstateを保存する（--save_last_n_epochsの指定を上書きする）",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--save_last_n_steps",
         type=int,
         default=None,
-        help="save checkpoints until N steps elapsed (remove older checkpoints if N steps elapsed) / 指定ステップごとにモデルを保存するとき、このステップ数経過するまで保存する（このステップ数経過したら削除する）",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--save_last_n_steps_state",
         type=int,
         default=None,
-        help="save states until N steps elapsed (remove older states if N steps elapsed, overrides --save_last_n_steps) / 指定ステップごとにstateを保存するとき、このステップ数経過するまで保存する（このステップ数経過したら削除する。--save_last_n_stepsを上書きする）",
+        help=argparse.SUPPRESS,
     )
     parser.add_argument(
         "--async_checkpoint_save",

--- a/src/musubi_tuner/training/trainer_base.py
+++ b/src/musubi_tuner/training/trainer_base.py
@@ -2504,7 +2504,9 @@ class NetworkTrainer:
                                 )
 
                             if accelerator.is_main_process:
-                                remove_step_no = train_utils.get_remove_step_no(args, global_step) if scheduled_saving else None
+                                remove_step_no = (
+                                    train_utils.get_remove_ckpt_no(args, global_step, args.save_every_n_steps) if scheduled_saving else None
+                                )
                                 if remove_step_no is not None:
                                     remove_ckpt_name = train_utils.get_step_ckpt_name(args.output_name, remove_step_no)
                                     remove_model(remove_ckpt_name)
@@ -2592,7 +2594,7 @@ class NetworkTrainer:
                         ckpt_name = train_utils.get_epoch_ckpt_name(args.output_name, epoch + 1)
                         save_model(ckpt_name, accelerator.unwrap_model(network), global_step, epoch + 1, allow_async=True)
 
-                        remove_epoch_no = train_utils.get_remove_epoch_no(args, epoch + 1)
+                        remove_epoch_no = train_utils.get_remove_ckpt_no(args, epoch + 1, args.save_every_n_epochs)
                         if remove_epoch_no is not None:
                             remove_ckpt_name = train_utils.get_epoch_ckpt_name(args.output_name, remove_epoch_no)
                             remove_model(remove_ckpt_name)

--- a/src/musubi_tuner/utils/train_utils.py
+++ b/src/musubi_tuner/utils/train_utils.py
@@ -292,29 +292,24 @@ def get_last_ckpt_name(model_name):
     return model_name + ".safetensors"
 
 
-def resolve_save_retention(args: argparse.Namespace, *, state: bool = False) -> int | None:
-    """Resolve how many checkpoints (or checkpoint states) to keep on disk.
+def resolve_save_retention(args: argparse.Namespace) -> int | None:
+    """Resolve how many checkpoints to keep on disk.
 
     Single source of truth for retention: ``--save_last_n_checkpoints`` wins; the
-    legacy ``--save_last_n_{steps,epochs}`` flags alias onto the same count when it
-    is not set. The value is a *checkpoint count*, never a step/epoch window, and it
-    behaves identically for epoch-based and step-based saving. With ``state=True``,
-    ``--save_last_n_checkpoints_state`` (or its legacy aliases) wins and falls back
-    to the plain checkpoint count.
+    legacy ``--save_last_n_{steps,epochs}[_state]`` flags alias onto the same count
+    when it is not set. The value is a *checkpoint count*, never a step/epoch window,
+    and it behaves identically for epoch-based and step-based saving. States are
+    saved and pruned in lockstep with their checkpoints, so there is deliberately no
+    separate state count: one flag, one synchronized history on disk.
     """
-    names = ["save_last_n_checkpoints", "save_last_n_steps", "save_last_n_epochs"]
-    if state:
-        names = [f"{name}_state" for name in names]
-    for name in names:
+    for name in ("save_last_n_checkpoints", "save_last_n_steps", "save_last_n_epochs", "save_last_n_steps_state", "save_last_n_epochs_state"):
         value = getattr(args, name, None)
         if value is not None:
             return value
-    if state:
-        return resolve_save_retention(args)  # states fall back to the checkpoint count
     return None
 
 
-def get_remove_ckpt_no(args: argparse.Namespace, current_no: int, save_every_n: int | None, *, state: bool = False) -> int | None:
+def get_remove_ckpt_no(args: argparse.Namespace, current_no: int, save_every_n: int | None) -> int | None:
     """Return the cadence slot to delete so only the last N checkpoints remain.
 
     Single retention core for both cadences: at each save, the checkpoint written
@@ -323,7 +318,7 @@ def get_remove_ckpt_no(args: argparse.Namespace, current_no: int, save_every_n: 
     ``save_last_n=8`` keeps 8 checkpoints even when they are 400 steps apart.
     Returns ``None`` when retention is disabled or nothing is old enough to remove.
     """
-    keep_n = resolve_save_retention(args, state=state)
+    keep_n = resolve_save_retention(args)
     if keep_n is None or not save_every_n:
         return None
 
@@ -367,7 +362,7 @@ def save_and_remove_state_on_epoch_end(
             logger.info("uploading state to huggingface.")
             huggingface_utils.upload(args, state_dir, "/" + EPOCH_STATE_NAME.format(model_name, epoch_no))
 
-        remove_epoch_no = get_remove_ckpt_no(args, epoch_no, args.save_every_n_epochs, state=True)
+        remove_epoch_no = get_remove_ckpt_no(args, epoch_no, args.save_every_n_epochs)
         if remove_epoch_no is not None:
             state_dir_old = os.path.join(args.output_dir, EPOCH_STATE_NAME.format(model_name, remove_epoch_no))
             if os.path.exists(state_dir_old):
@@ -405,7 +400,7 @@ def save_and_remove_state_stepwise(
             huggingface_utils.upload(args, state_dir, "/" + STEP_STATE_NAME.format(model_name, step_no))
 
         # Same retention as the LoRA files, so a resume never finds a state newer than its checkpoint.
-        remove_step_no = get_remove_ckpt_no(args, step_no, args.save_every_n_steps, state=True) if apply_retention else None
+        remove_step_no = get_remove_ckpt_no(args, step_no, args.save_every_n_steps) if apply_retention else None
         if remove_step_no is not None:
             state_dir_old = os.path.join(args.output_dir, STEP_STATE_NAME.format(model_name, remove_step_no))
             if os.path.exists(state_dir_old):

--- a/src/musubi_tuner/utils/train_utils.py
+++ b/src/musubi_tuner/utils/train_utils.py
@@ -292,27 +292,46 @@ def get_last_ckpt_name(model_name):
     return model_name + ".safetensors"
 
 
-def get_remove_epoch_no(args: argparse.Namespace, epoch_no: int):
-    if args.save_last_n_epochs is None:
+def resolve_save_retention(args: argparse.Namespace, *, state: bool = False) -> int | None:
+    """Resolve how many checkpoints (or checkpoint states) to keep on disk.
+
+    Single source of truth for retention: ``--save_last_n_checkpoints`` wins; the
+    legacy ``--save_last_n_{steps,epochs}`` flags alias onto the same count when it
+    is not set. The value is a *checkpoint count*, never a step/epoch window, and it
+    behaves identically for epoch-based and step-based saving. With ``state=True``,
+    ``--save_last_n_checkpoints_state`` (or its legacy aliases) wins and falls back
+    to the plain checkpoint count.
+    """
+    names = ["save_last_n_checkpoints", "save_last_n_steps", "save_last_n_epochs"]
+    if state:
+        names = [f"{name}_state" for name in names]
+    for name in names:
+        value = getattr(args, name, None)
+        if value is not None:
+            return value
+    if state:
+        return resolve_save_retention(args)  # states fall back to the checkpoint count
+    return None
+
+
+def get_remove_ckpt_no(args: argparse.Namespace, current_no: int, save_every_n: int | None, *, state: bool = False) -> int | None:
+    """Return the cadence slot to delete so only the last N checkpoints remain.
+
+    Single retention core for both cadences: at each save, the checkpoint written
+    ``N * save_every_n`` units ago (epochs or steps) falls out of the keep window.
+    ``N`` comes from :func:`resolve_save_retention` — a checkpoint count, so
+    ``save_last_n=8`` keeps 8 checkpoints even when they are 400 steps apart.
+    Returns ``None`` when retention is disabled or nothing is old enough to remove.
+    """
+    keep_n = resolve_save_retention(args, state=state)
+    if keep_n is None or not save_every_n:
         return None
 
-    remove_epoch_no = epoch_no - args.save_every_n_epochs * args.save_last_n_epochs
-    if remove_epoch_no < 0:
+    # e.g. if save_every_n_steps=400, save_last_n_checkpoints=3, at step 1600 remove step 400 (keeps 800, 1200, 1600)
+    remove_no = current_no - save_every_n * keep_n
+    if remove_no < 0:
         return None
-    return remove_epoch_no
-
-
-def get_remove_step_no(args: argparse.Namespace, step_no: int):
-    if args.save_last_n_steps is None:
-        return None
-
-    # calculate the step number to remove from the last_n_steps and save_every_n_steps
-    # e.g. if save_every_n_steps=10, save_last_n_steps=30, at step 50, keep 30 steps and remove step 10
-    remove_step_no = step_no - args.save_last_n_steps - 1
-    remove_step_no = remove_step_no - (remove_step_no % args.save_every_n_steps)
-    if remove_step_no < 0:
-        return None
-    return remove_step_no
+    return remove_no
 
 
 def save_and_remove_state_on_epoch_end(
@@ -348,9 +367,8 @@ def save_and_remove_state_on_epoch_end(
             logger.info("uploading state to huggingface.")
             huggingface_utils.upload(args, state_dir, "/" + EPOCH_STATE_NAME.format(model_name, epoch_no))
 
-        last_n_epochs = args.save_last_n_epochs_state if args.save_last_n_epochs_state else args.save_last_n_epochs
-        if last_n_epochs is not None:
-            remove_epoch_no = epoch_no - args.save_every_n_epochs * last_n_epochs
+        remove_epoch_no = get_remove_ckpt_no(args, epoch_no, args.save_every_n_epochs, state=True)
+        if remove_epoch_no is not None:
             state_dir_old = os.path.join(args.output_dir, EPOCH_STATE_NAME.format(model_name, remove_epoch_no))
             if os.path.exists(state_dir_old):
                 logger.info(f"removing old state: {state_dir_old}")
@@ -386,19 +404,13 @@ def save_and_remove_state_stepwise(
             logger.info("uploading state to huggingface.")
             huggingface_utils.upload(args, state_dir, "/" + STEP_STATE_NAME.format(model_name, step_no))
 
-        last_n_steps = (
-            (args.save_last_n_steps_state if args.save_last_n_steps_state else args.save_last_n_steps) if apply_retention else None
-        )
-        if last_n_steps is not None:
-            # last_n_steps前のstep_noから、save_every_n_stepsの倍数のstep_noを計算して削除する
-            remove_step_no = step_no - last_n_steps - 1
-            remove_step_no = remove_step_no - (remove_step_no % args.save_every_n_steps)
-
-            if remove_step_no > 0:
-                state_dir_old = os.path.join(args.output_dir, STEP_STATE_NAME.format(model_name, remove_step_no))
-                if os.path.exists(state_dir_old):
-                    logger.info(f"removing old state: {state_dir_old}")
-                    shutil.rmtree(state_dir_old)
+        # Same retention as the LoRA files, so a resume never finds a state newer than its checkpoint.
+        remove_step_no = get_remove_ckpt_no(args, step_no, args.save_every_n_steps, state=True) if apply_retention else None
+        if remove_step_no is not None:
+            state_dir_old = os.path.join(args.output_dir, STEP_STATE_NAME.format(model_name, remove_step_no))
+            if os.path.exists(state_dir_old):
+                logger.info(f"removing old state: {state_dir_old}")
+                shutil.rmtree(state_dir_old)
     accelerator.wait_for_everyone()
 
 

--- a/src/musubi_tuner/zimage_train.py
+++ b/src/musubi_tuner/zimage_train.py
@@ -595,7 +595,7 @@ class ZImageTrainer(ZImageNetworkTrainer):
                                 if args.save_state:
                                     train_utils.save_and_remove_state_stepwise(args, accelerator, global_step)
 
-                                remove_step_no = train_utils.get_remove_step_no(args, global_step)
+                                remove_step_no = train_utils.get_remove_ckpt_no(args, global_step, args.save_every_n_steps)
                                 if remove_step_no is not None:
                                     remove_ckpt_name = train_utils.get_step_ckpt_name(args.output_name, remove_step_no)
                                     remove_model(remove_ckpt_name)
@@ -636,7 +636,7 @@ class ZImageTrainer(ZImageNetworkTrainer):
                         use_memory_efficient_saving=args.mem_eff_save,
                     )
 
-                    remove_epoch_no = train_utils.get_remove_epoch_no(args, epoch + 1)
+                    remove_epoch_no = train_utils.get_remove_ckpt_no(args, epoch + 1, args.save_every_n_epochs)
                     if remove_epoch_no is not None:
                         remove_ckpt_name = train_utils.get_epoch_ckpt_name(args.output_name, remove_epoch_no)
                         remove_model(remove_ckpt_name)

--- a/tests/test_checkpoint_retention.py
+++ b/tests/test_checkpoint_retention.py
@@ -179,3 +179,27 @@ class TestStateSaverIntegration:
             args, self._accelerator(saved), 501, epoch=1, step_in_epoch=0, apply_retention=False
         )
         assert (tmp_path / "run-step00000501-state").exists()
+
+
+class TestProjectConfigMigration:
+    def test_legacy_retention_fields_fold_into_unified_option(self):
+        from musubi_tuner.gui_dashboard.project_schema import ProjectConfig
+
+        config = ProjectConfig.model_validate(
+            {
+                "version": 1,
+                "training": {"save_last_n_steps": 5, "save_last_n_epochs_state": 2},
+                "full_finetune": {"save_last_n_steps": 3},
+            }
+        )
+        assert config.training.save_last_n_checkpoints == 5
+        assert config.training.save_last_n_checkpoints_state == 2
+        assert config.full_finetune.save_last_n_checkpoints == 3
+
+    def test_unified_value_wins_over_legacy(self):
+        from musubi_tuner.gui_dashboard.project_schema import ProjectConfig
+
+        config = ProjectConfig.model_validate(
+            {"version": 1, "training": {"save_last_n_steps": 5, "save_last_n_checkpoints": 9}}
+        )
+        assert config.training.save_last_n_checkpoints == 9

--- a/tests/test_checkpoint_retention.py
+++ b/tests/test_checkpoint_retention.py
@@ -1,0 +1,181 @@
+"""Unified checkpoint retention: keep the last N checkpoints, epoch- or step-based.
+
+Regression coverage for the retention overhaul: ``--save_last_n_checkpoints`` is a
+checkpoint count for both cadences, the legacy ``--save_last_n_{steps,epochs}`` flags
+alias onto it, and ``--save_last_n_checkpoints_state`` overrides / falls back the same
+way the old state flags did.
+"""
+
+from types import SimpleNamespace
+
+from musubi_tuner.utils import train_utils
+
+
+def _args(**overrides):
+    args = SimpleNamespace(
+        save_last_n_checkpoints=None,
+        save_last_n_checkpoints_state=None,
+        save_last_n_epochs=None,
+        save_last_n_epochs_state=None,
+        save_last_n_steps=None,
+        save_last_n_steps_state=None,
+        save_every_n_epochs=None,
+        save_every_n_steps=None,
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+class TestIssueScenario:
+    """save_every_n_steps=400 + keep 8 must keep 8 checkpoints, not only the newest."""
+
+    def test_widely_spaced_step_checkpoints_survive(self):
+        args = _args(save_last_n_steps=8, save_every_n_steps=400)
+
+        # Before the fix this removed anything older than 8 steps: every save deleted
+        # all prior checkpoints. Now step 3200 removes step 0 and keeps 800..3200.
+        assert train_utils.get_remove_ckpt_no(args, 3200, 400) == 0
+        assert train_utils.get_remove_ckpt_no(args, 2800, 400) is None  # nothing old enough yet
+
+    def test_keep_window_is_count_not_steps(self):
+        args = _args(save_last_n_steps=3, save_every_n_steps=400)
+
+        for step in (400, 800, 1200):
+            assert train_utils.get_remove_ckpt_no(args, 1200, 400) == 0
+        assert train_utils.get_remove_ckpt_no(args, 1600, 400) == 400
+
+
+class TestUnifiedOption:
+    def test_new_flag_drives_step_retention(self):
+        args = _args(save_last_n_checkpoints=2, save_every_n_steps=400)
+        assert train_utils.get_remove_ckpt_no(args, 1600, 400) == 800
+        # At 1200 the set is {400, 800, 1200}; removing 400 keeps the last 2.
+        assert train_utils.get_remove_ckpt_no(args, 1200, 400) == 400
+        # At 800 the formula targets step 0, whose checkpoint never existed — a
+        # harmless no-op that the state saver / remove_model already tolerate.
+        assert train_utils.get_remove_ckpt_no(args, 800, 400) == 0
+
+    def test_new_flag_drives_epoch_retention(self):
+        args = _args(save_last_n_checkpoints=2, save_every_n_epochs=5)
+        assert train_utils.get_remove_ckpt_no(args, 11, 5) == 1
+        assert train_utils.get_remove_ckpt_no(args, 6, 5) is None
+
+    def test_epoch_and_step_cadence_share_one_formula(self):
+        every, keep = 5, 3
+        step_args = _args(save_last_n_checkpoints=keep, save_every_n_steps=every)
+        epoch_args = _args(save_last_n_checkpoints=keep, save_every_n_epochs=every)
+        for current in range(every, every * keep):
+            assert train_utils.get_remove_ckpt_no(step_args, current, every) is None
+            assert train_utils.get_remove_ckpt_no(epoch_args, current, every) is None
+        for current in range(every * keep, every * 10):
+            assert train_utils.get_remove_ckpt_no(step_args, current, every) == train_utils.get_remove_ckpt_no(
+                epoch_args, current, every
+            )
+
+
+class TestLegacyAliases:
+    def test_save_last_n_steps_aliases_count_semantics(self):
+        args = _args(save_last_n_steps=4, save_every_n_steps=250)
+        assert train_utils.get_remove_ckpt_no(args, 2000, 250) == 1000  # removes the 5th-newest slot
+
+    def test_save_last_n_epochs_aliases_count_semantics(self):
+        args = _args(save_last_n_epochs=4, save_every_n_epochs=2)
+        assert train_utils.get_remove_ckpt_no(args, 10, 2) == 2
+
+    def test_new_flag_wins_over_legacy_aliases(self):
+        args = _args(save_last_n_checkpoints=2, save_last_n_steps=10, save_last_n_epochs=10, save_every_n_steps=100)
+        assert train_utils.resolve_save_retention(args) == 2
+
+
+class TestStateRetention:
+    def test_state_flag_overrides_checkpoint_count(self):
+        args = _args(save_last_n_checkpoints=8, save_last_n_checkpoints_state=1, save_every_n_steps=400)
+        assert train_utils.resolve_save_retention(args, state=True) == 1
+
+    def test_state_falls_back_to_checkpoint_count(self):
+        args = _args(save_last_n_checkpoints=8, save_every_n_steps=400)
+        assert train_utils.resolve_save_retention(args, state=True) == 8
+
+    def test_legacy_state_aliases_still_work(self):
+        args = _args(save_last_n_steps_state=2, save_every_n_steps=400)
+        assert train_utils.resolve_save_retention(args, state=True) == 2
+        args = _args(save_last_n_epochs_state=3, save_every_n_epochs=1)
+        assert train_utils.resolve_save_retention(args, state=True) == 3
+
+    def test_no_retention_anywhere(self):
+        args = _args()
+        assert train_utils.resolve_save_retention(args) is None
+        assert train_utils.resolve_save_retention(args, state=True) is None
+        assert train_utils.get_remove_ckpt_no(args, 10**6, 100) is None
+
+
+class TestStateSaverIntegration:
+    def _accelerator(self, saved):
+        class Accelerator:
+            is_main_process = True
+
+            def save_state(self, state_dir):
+                from pathlib import Path
+
+                Path(state_dir).mkdir(parents=True, exist_ok=True)
+                saved.append(state_dir)
+
+            def wait_for_everyone(self):
+                pass
+
+        return Accelerator()
+
+    def test_stepwise_state_saver_applies_count_retention(self, tmp_path):
+        saved = []
+        args = _args(
+            save_last_n_steps=2,
+            save_every_n_steps=400,
+            output_dir=str(tmp_path),
+            output_name="run",
+            save_state_to_huggingface=False,
+            seed=None,
+        )
+        for step in (400, 800, 1200):
+            train_utils.save_and_remove_state_stepwise(args, self._accelerator(saved), step, epoch=1, step_in_epoch=0)
+
+        assert (tmp_path / "run-step00000400-state").exists() is False  # rotated out
+        assert (tmp_path / "run-step00000800-state").exists()
+        assert (tmp_path / "run-step00001200-state").exists()
+        assert len(saved) == 3
+
+    def test_epoch_end_state_saver_applies_count_retention(self, tmp_path):
+        saved = []
+        args = _args(
+            save_last_n_epochs=2,
+            save_every_n_epochs=1,
+            output_dir=str(tmp_path),
+            output_name="run",
+            save_state_to_huggingface=False,
+            seed=None,
+        )
+        for epoch in (1, 2, 3, 4):
+            train_utils.save_and_remove_state_on_epoch_end(args, self._accelerator(saved), epoch)
+
+        assert (tmp_path / "run-000001-state").exists() is False
+        assert (tmp_path / "run-000002-state").exists() is False
+        assert (tmp_path / "run-000003-state").exists()
+        assert (tmp_path / "run-000004-state").exists()
+        assert len(saved) == 4
+
+    def test_stepwise_state_saver_can_skip_retention_for_request_saves(self, tmp_path):
+        saved = []
+        args = _args(
+            save_last_n_steps=2,
+            save_every_n_steps=400,
+            output_dir=str(tmp_path),
+            output_name="run",
+            save_state_to_huggingface=False,
+            seed=None,
+        )
+        # Ad-hoc save via request file at an off-cadence step: apply_retention=False must
+        # leave every previously kept state in place.
+        train_utils.save_and_remove_state_stepwise(
+            args, self._accelerator(saved), 501, epoch=1, step_in_epoch=0, apply_retention=False
+        )
+        assert (tmp_path / "run-step00000501-state").exists()

--- a/tests/test_checkpoint_retention.py
+++ b/tests/test_checkpoint_retention.py
@@ -1,9 +1,9 @@
 """Unified checkpoint retention: keep the last N checkpoints, epoch- or step-based.
 
 Regression coverage for the retention overhaul: ``--save_last_n_checkpoints`` is a
-checkpoint count for both cadences, the legacy ``--save_last_n_{steps,epochs}`` flags
-alias onto it, and ``--save_last_n_checkpoints_state`` overrides / falls back the same
-way the old state flags did.
+checkpoint count for both cadences, the legacy ``--save_last_n_{steps,epochs}[_state]``
+flags alias onto it, and states are pruned in lockstep with their checkpoints —
+there is deliberately no separate state count.
 """
 
 from types import SimpleNamespace
@@ -14,7 +14,6 @@ from musubi_tuner.utils import train_utils
 def _args(**overrides):
     args = SimpleNamespace(
         save_last_n_checkpoints=None,
-        save_last_n_checkpoints_state=None,
         save_last_n_epochs=None,
         save_last_n_epochs_state=None,
         save_last_n_steps=None,
@@ -88,25 +87,28 @@ class TestLegacyAliases:
         assert train_utils.resolve_save_retention(args) == 2
 
 
-class TestStateRetention:
-    def test_state_flag_overrides_checkpoint_count(self):
-        args = _args(save_last_n_checkpoints=8, save_last_n_checkpoints_state=1, save_every_n_steps=400)
-        assert train_utils.resolve_save_retention(args, state=True) == 1
+class TestStateLockstep:
+    """States and their checkpoints share one count — no separate state knob."""
 
-    def test_state_falls_back_to_checkpoint_count(self):
+    def test_states_use_the_checkpoint_count(self):
         args = _args(save_last_n_checkpoints=8, save_every_n_steps=400)
-        assert train_utils.resolve_save_retention(args, state=True) == 8
+        # The state savers call the same get_remove_ckpt_no as checkpoint removal:
+        # one flag drives both.
+        assert train_utils.get_remove_ckpt_no(args, 3200, 400) == 0
 
-    def test_legacy_state_aliases_still_work(self):
+    def test_legacy_state_flags_fold_into_the_shared_count(self):
         args = _args(save_last_n_steps_state=2, save_every_n_steps=400)
-        assert train_utils.resolve_save_retention(args, state=True) == 2
+        assert train_utils.resolve_save_retention(args) == 2
         args = _args(save_last_n_epochs_state=3, save_every_n_epochs=1)
-        assert train_utils.resolve_save_retention(args, state=True) == 3
+        assert train_utils.resolve_save_retention(args) == 3
+
+    def test_new_flag_wins_over_legacy_state_flags(self):
+        args = _args(save_last_n_checkpoints=6, save_last_n_steps_state=2, save_every_n_steps=400)
+        assert train_utils.resolve_save_retention(args) == 6
 
     def test_no_retention_anywhere(self):
         args = _args()
         assert train_utils.resolve_save_retention(args) is None
-        assert train_utils.resolve_save_retention(args, state=True) is None
         assert train_utils.get_remove_ckpt_no(args, 10**6, 100) is None
 
 
@@ -193,7 +195,6 @@ class TestProjectConfigMigration:
             }
         )
         assert config.training.save_last_n_checkpoints == 5
-        assert config.training.save_last_n_checkpoints_state == 2
         assert config.full_finetune.save_last_n_checkpoints == 3
 
     def test_unified_value_wins_over_legacy(self):

--- a/tests/test_resume_state.py
+++ b/tests/test_resume_state.py
@@ -24,6 +24,8 @@ def _save_args(tmp_path):
         output_name="dataset",
         output_dir=str(tmp_path),
         save_state_to_huggingface=False,
+        save_last_n_checkpoints_state=None,
+        save_last_n_checkpoints=None,
         save_last_n_epochs_state=None,
         save_last_n_epochs=None,
         save_every_n_epochs=1,


### PR DESCRIPTION
Closes #122.

## Summary

Collapses the four retention flags into **one rule: keep the last N checkpoints** — identical whether saving every few epochs or every few steps.

- New `--save_last_n_checkpoints N`: keeps the last N checkpoints **and their matching `--save_state` states**, saved and pruned in lockstep. One flag, one synchronized history on disk — there is deliberately no separate state count.
- `--save_every_n_steps 400 --save_last_n_steps 8` previously kept **only the newest** checkpoint (it was a step window, not a count). Now that config keeps 8.
- Legacy `save_last_n_{steps,epochs}[_state]` flags remain as **hidden aliases** with corrected count semantics — existing TOMLs and commands keep parsing, old step-window behavior is gone.
- One retention core (`resolve_save_retention` + `get_remove_ckpt_no`) replaces `get_remove_epoch_no` / `get_remove_step_no` and the window math duplicated inline in `save_and_remove_state_stepwise`.
- GUI dashboard: project configs migrate legacy retention fields (training + full_finetune) onto `save_last_n_checkpoints`; command builders emit the new flag; the storage estimator uses the count directly (no more phantom +1 checkpoint).

## Files (14)

`train_utils.py` (core) · `parser_common.py`, `hv_train.py` (flag) · `trainer_base.py`, `qwen_image_train.py`, `zimage_train.py`, `hidream_o1_train.py` (call sites) · `gui_dashboard/` (schema migration, command builders, stats, 2 svelte pages) · `tests/test_checkpoint_retention.py` (new: issue scenario, epoch/step parity, legacy aliases, state lockstep, request-file saves, config migration) · `tests/test_resume_state.py` (fixture)

## Notes

- Built frontend `dist/` refresh is the usual separate `build(dashboard)` pass.
- Epoch-based configs see no behavior change — epochs were already count-based.